### PR TITLE
Add FanDuel settled-slip fallback parser

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -265,10 +265,8 @@ def _find_matching_pending_bet(partial_bet: dict) -> dict | None:
 
     if len(matches) == 0:
         return None
-    if len(matches) == 1:
-        return matches.iloc[0].to_dict()
 
-    # Multiple matches -- narrow by team name
+    # Verify team name against every candidate (even single matches)
     teams = partial_bet.get("_teams", [])
     for _, row in matches.iterrows():
         line_upper = str(row.get("line", "")).upper()
@@ -277,6 +275,14 @@ def _find_matching_pending_bet(partial_bet: dict) -> dict | None:
             if team.upper() in line_upper or team.upper() in game_upper:
                 return row.to_dict()
 
+    # Single match with no team info -- accept it as best guess
+    if len(matches) == 1 and not teams:
+        return matches.iloc[0].to_dict()
+
+    logger.info(
+        f"Could not narrow pending bet match: {len(matches)} candidates, "
+        f"teams={teams}"
+    )
     return None
 
 


### PR DESCRIPTION
## Summary
- Add `_parse_fd_settled_fallback` that extracts teams from score lines, odds, wager, payout, and result when OCR misses the styled FD header (e.g. "UTSA +12.5")
- Add `_find_matching_pending_bet` to auto-settle pending bets by matching on platform + wager + team name
- Add partial bet completion flow: if no pending match, bot prompts user for "TEAM SPREAD" to finish logging
- Expand `VALID_SHORT_TEAMS` with VMI, UTSA, UTEP, UNLV, and other short team names that were being filtered as OCR junk

## Test plan
- [ ] Send a settled FD screenshot where OCR misses the header -- verify fallback detects teams/amounts and matches pending bet
- [ ] Send a settled FD screenshot with no matching pending bet -- verify bot prompts for TEAM SPREAD
- [ ] Reply with "UTSA +12.5" style input -- verify bet gets logged with correct result/profit
- [ ] Send a normal (unsettled) FD screenshot -- verify existing parser still works
- [ ] Verify short team names (VMI, UTSA, etc.) survive OCR cleaning

🤖 Generated with [Claude Code](https://claude.com/claude-code)