### PR TITLE
Fix grading to filter by STRONG rating instead of raw confidence

### DIFF
--- a/grade_predictions.py
+++ b/grade_predictions.py
@@ -185,8 +185,18 @@ def grade_predictions():
         print(f"Loaded {total_preds} predictions from file")
         
         # Filter for actionable bets only (STRONG rating from either source)
-        std_rating = preds['Std_Rating'] if 'Std_Rating' in preds.columns else pd.Series('PASS', index=preds.index)
-        kalshi_rating = preds['Rating'] if 'Rating' in preds.columns else pd.Series('PASS', index=preds.index)
+        has_std = 'Std_Rating' in preds.columns
+        has_kalshi = 'Rating' in preds.columns
+
+        if not has_std and not has_kalshi:
+            print("ERROR: Prediction file has neither 'Std_Rating' nor 'Rating' column.")
+            print("   Cannot determine which bets are actionable.")
+            print(f"   Columns found: {list(preds.columns)}")
+            print("   Re-run predict.py to generate a file with rating columns.")
+            return
+
+        std_rating = preds['Std_Rating'] if has_std else pd.Series('PASS', index=preds.index)
+        kalshi_rating = preds['Rating'].fillna('PASS') if has_kalshi else pd.Series('PASS', index=preds.index)
         preds = preds[
             (std_rating == 'STRONG') | (kalshi_rating == 'STRONG')
         ].copy()


### PR DESCRIPTION
## Summary
- `grade_predictions.py` was grading all bets with >=53% confidence, including PASS-rated bets the dashboard would never recommend
- Now filters by `Std_Rating == 'STRONG'` or `Rating == 'STRONG'`, matching the dashboard and telegram bot logic
- Performance metrics now reflect actual recommended bets only

Closes #11

## Test plan
- [ ] Run `grade_predictions.py` against a dated predictions file that has both STRONG and PASS bets, verify only STRONG bets are graded
- [ ] Verify `performance_log.csv` output only contains STRONG-rated entries

Generated with [Claude Code](https://claude.com/claude-code)