### PR TITLE
Add Polymarket as additional odds source via Gamma API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,11 @@ TELEGRAM_BOT_TOKEN=your_bot_token_here
 # To get your user ID, message @userinfobot on Telegram
 # Leave empty to allow all users (NOT RECOMMENDED)
 TELEGRAM_ALLOWED_USERS=123456789
+
+# Polymarket Configuration
+# SOCKS5 proxy for geo-restricted access (required for US users)
+# Start tunnel: ssh -N linode-syd  (uses DynamicForward 8080 from SSH config)
+POLYMARKET_PROXY=socks5://127.0.0.1:8080
+
+# Polygon wallet address for position tracking/settlement
+POLYMARKET_WALLET_ADDRESS=0x_your_wallet_address_here

--- a/app.py
+++ b/app.py
@@ -804,8 +804,10 @@ def _fetch_kalshi_positions():
         return []
 
 
-def _event_ticker(ticker: str) -> str:
+def _event_ticker(ticker) -> str:
     """Extract event ticker (drop market suffix) for game-level matching."""
+    if not ticker or not isinstance(ticker, str):
+        return ""
     parts = ticker.rsplit("-", 1)
     return parts[0] if len(parts) > 1 else ticker
 

--- a/app.py
+++ b/app.py
@@ -688,11 +688,11 @@ def kalshi_event_url(ticker) -> str:
     return f"https://kalshi.com/markets/{series.lower()}/{slug}/{event_ticker.lower()}"
 
 
-def polymarket_event_url(token_id) -> str:
-    """Build a Polymarket URL from a token/condition ID or slug."""
-    if not token_id or not isinstance(token_id, str):
+def polymarket_event_url(slug_or_id) -> str:
+    """Build a Polymarket event URL from an event slug or token ID."""
+    if not slug_or_id or not isinstance(slug_or_id, str):
         return ""
-    return f"https://polymarket.com/event/{token_id}"
+    return f"https://polymarket.com/event/{slug_or_id}"
 
 
 def _esc(val) -> str:

--- a/app.py
+++ b/app.py
@@ -386,6 +386,28 @@ p, span, div, .stMarkdown {
     color: var(--green-700);
 }
 
+/* Polymarket badge */
+.poly-row {
+    background: var(--neutral-50);
+    border: 1px solid #c7d2fe;
+    border-radius: 6px;
+    padding: 6px 10px;
+    margin-top: 4px;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    color: #312e81;
+}
+.poly-link {
+    color: #6366f1;
+    text-decoration: none;
+    font-size: 0.72rem;
+    font-weight: 500;
+}
+.poly-link:hover {
+    text-decoration: underline;
+    color: #4f46e5;
+}
+
 /* Summary KPI row */
 .kpi-row {
     display: flex;
@@ -664,6 +686,13 @@ def kalshi_event_url(ticker) -> str:
     if not slug:
         return f"https://kalshi.com/markets/{series.lower()}"
     return f"https://kalshi.com/markets/{series.lower()}/{slug}/{event_ticker.lower()}"
+
+
+def polymarket_event_url(token_id) -> str:
+    """Build a Polymarket URL from a token/condition ID or slug."""
+    if not token_id or not isinstance(token_id, str):
+        return ""
+    return f"https://polymarket.com/event/{token_id}"
 
 
 def _esc(val) -> str:
@@ -1202,15 +1231,21 @@ def _render_spread_bets(col, lg, position_lookup=None):
         spread_value_bets = pd.DataFrame(columns=spread_df.columns) if not spread_df.empty else pd.DataFrame()
         if not spread_df.empty and 'Std_Rating' in spread_df.columns:
             spread_rating = spread_df['Rating'] if 'Rating' in spread_df.columns else pd.Series('PASS', index=spread_df.index)
+            poly_spread_rating = spread_df['Poly_Rating'] if 'Poly_Rating' in spread_df.columns else pd.Series('PASS', index=spread_df.index)
             spread_value_bets = spread_df[
                 (spread_df['Std_Rating'].isin(VALUE_RATINGS)) |
-                (spread_rating.isin(VALUE_RATINGS))
+                (spread_rating.isin(VALUE_RATINGS)) |
+                (poly_spread_rating.isin(VALUE_RATINGS))
             ].copy()
 
         if len(spread_value_bets) > 0:
+            poly_edge = _parse_edge(spread_value_bets['Poly_Edge_Pct']) if 'Poly_Edge_Pct' in spread_value_bets.columns else pd.Series(0.0, index=spread_value_bets.index)
             spread_value_bets['_best_edge'] = np.maximum(
-                _parse_edge(spread_value_bets['Std_Edge_Pct']),
-                _parse_edge(spread_value_bets['Edge_Pct']),
+                np.maximum(
+                    _parse_edge(spread_value_bets['Std_Edge_Pct']),
+                    _parse_edge(spread_value_bets['Edge_Pct']),
+                ),
+                poly_edge,
             )
             spread_value_bets = (
                 spread_value_bets
@@ -1224,16 +1259,27 @@ def _render_spread_bets(col, lg, position_lookup=None):
                 conf = row['Conf']
                 game_time = row.get('Date/Time', '')
 
+                poly_rating = row.get('Poly_Rating', 'PASS') if pd.notna(row.get('Poly_Rating')) else 'PASS'
                 std_rank_val = RATING_RANK.get(std_rating, 0)
                 kalshi_rank_val = RATING_RANK.get(kalshi_rating, 0)
-                kalshi_is_primary = kalshi_rank_val > std_rank_val
-                best_rating = kalshi_rating if kalshi_is_primary else std_rating
+                poly_rank_val = RATING_RANK.get(poly_rating, 0)
+                best_rank = max(std_rank_val, kalshi_rank_val, poly_rank_val)
+                if kalshi_rank_val == best_rank:
+                    best_rating = kalshi_rating
+                elif poly_rank_val == best_rank:
+                    best_rating = poly_rating
+                else:
+                    best_rating = std_rating
                 badge_css = best_rating.lower()
 
-                if kalshi_is_primary:
+                if kalshi_rank_val == best_rank and kalshi_rank_val > 0:
                     display_edge = row.get('Edge_Pct', 'N/A')
                     display_units = row.get('Units', 0) or 0
                     edge_source = "Kalshi Edge"
+                elif poly_rank_val == best_rank and poly_rank_val > 0:
+                    display_edge = row.get('Poly_Edge_Pct', 'N/A')
+                    display_units = row.get('Poly_Units', 0) or 0
+                    edge_source = "Poly Edge"
                 else:
                     display_edge = row.get('Std_Edge_Pct', 'N/A')
                     display_units = row.get('Std_Units', 0) or 0
@@ -1261,6 +1307,24 @@ def _render_spread_bets(col, lg, position_lookup=None):
                         kalshi_html = f'<div class="kalshi-row"><a href="{kalshi_url}" target="_blank" class="kalshi-link">{kalshi_text}</a></div>'
                     else:
                         kalshi_html = f'<div class="kalshi-row"><span class="kalshi-label">{kalshi_text}</span></div>'
+
+                # Polymarket spread display
+                poly_side = row.get('Poly_Side')
+                poly_price = row.get('Poly_Price')
+                has_poly = pd.notna(poly_side) and poly_side if isinstance(poly_side, str) else False
+
+                poly_html = ""
+                if has_poly:
+                    poly_edge = _esc(row.get('Poly_Edge_Pct', 'N/A'))
+                    poly_fee = row.get('Poly_Fee')
+                    poly_fee_str = f" + {_esc(poly_fee)}&#162; fee" if pd.notna(poly_fee) and poly_fee else ""
+                    poly_ticker = row.get('Poly_Ticker', '')
+                    poly_text = f"Poly {_esc(row.get('Pick', ''))} @ {_esc(poly_price)}&#162;{poly_fee_str} ({_esc(poly_side)} side) &middot; {poly_edge}"
+                    if poly_ticker:
+                        poly_url = _esc(polymarket_event_url(poly_ticker))
+                        poly_html = f'<div class="poly-row"><a href="{poly_url}" target="_blank" class="poly-link">{poly_text}</a></div>'
+                    else:
+                        poly_html = f'<div class="poly-row"><span class="kalshi-label">{poly_text}</span></div>'
 
                 placed_html = _placed_badge_html(kalshi_ticker, position_lookup or {})
 
@@ -1295,6 +1359,7 @@ def _render_spread_bets(col, lg, position_lookup=None):
                         </div>
                     </div>
                     {kalshi_html}
+                    {poly_html}
                 </div>
                 ''', unsafe_allow_html=True)
 
@@ -1330,7 +1395,9 @@ def _render_game_bets(col, lg, position_lookup=None):
             st.caption("No ML game markets on this slate.")
             return
 
-        game_value = game_df[game_df['Rating'].isin(VALUE_RATINGS)].copy() if 'Rating' in game_df.columns else pd.DataFrame()
+        kalshi_game_val = game_df['Rating'].isin(VALUE_RATINGS) if 'Rating' in game_df.columns else pd.Series(False, index=game_df.index)
+        poly_game_val = game_df['Poly_Rating'].isin(VALUE_RATINGS) if 'Poly_Rating' in game_df.columns else pd.Series(False, index=game_df.index)
+        game_value = game_df[kalshi_game_val | poly_game_val].copy()
         if game_value.empty:
             st.caption("No ML game markets on this slate.")
             return
@@ -1354,6 +1421,22 @@ def _render_game_bets(col, lg, position_lookup=None):
                 game_kalshi_html = f'<a href="{game_kalshi_url}" target="_blank" class="kalshi-link">{game_kalshi_text}</a>'
             else:
                 game_kalshi_html = f'<span class="kalshi-label">{game_kalshi_text}</span>'
+            # Polymarket game display
+            game_poly_side = row.get('Poly_Side')
+            game_has_poly = pd.notna(game_poly_side) and game_poly_side if isinstance(game_poly_side, str) else False
+            game_poly_html = ""
+            if game_has_poly:
+                game_poly_edge = _esc(row.get('Poly_Edge_Pct', 'N/A'))
+                game_poly_fee = row.get('Poly_Fee')
+                game_poly_fee_str = f" + {float(game_poly_fee):.1f}&#162; fee" if pd.notna(game_poly_fee) and game_poly_fee else ""
+                game_poly_ticker = row.get('Poly_Ticker', '')
+                game_poly_text = f"Poly {game_pick} @ {_esc(row.get('Poly_Price', ''))}&#162;{game_poly_fee_str} ({_esc(game_poly_side)} side) &middot; {game_poly_edge}"
+                if game_poly_ticker:
+                    game_poly_url = _esc(polymarket_event_url(game_poly_ticker))
+                    game_poly_html = f'<div class="poly-row"><a href="{game_poly_url}" target="_blank" class="poly-link">{game_poly_text}</a></div>'
+                else:
+                    game_poly_html = f'<div class="poly-row"><span class="kalshi-label">{game_poly_text}</span></div>'
+
             placed_html = _placed_badge_html(game_kalshi_ticker, position_lookup or {})
             st.markdown(f'''
             <div class="bet-card {badge_css} {card_extra}">
@@ -1386,6 +1469,7 @@ def _render_game_bets(col, lg, position_lookup=None):
                     </div>
                 </div>
                 <div class="kalshi-row">{game_kalshi_html}</div>
+                {game_poly_html}
             </div>
             ''', unsafe_allow_html=True)
 

--- a/app.py
+++ b/app.py
@@ -1303,7 +1303,7 @@ def _render_spread_bets(col, lg, position_lookup=None):
                     kalshi_fee = row.get('Kalshi_Fee')
                     fee_str = f" + {_esc(kalshi_fee)}&#162; fee" if pd.notna(kalshi_fee) and kalshi_fee else ""
                     cbb_pick = _esc(row.get('Pick', ''))
-                    kalshi_text = f"Kalshi {cbb_pick} @ {_esc(kalshi_price)}&#162;{fee_str} ({_esc(kalshi_side)} side) &middot; {kalshi_edge}"
+                    kalshi_text = f"Kalshi: Buy {_esc(kalshi_side)} @ {_esc(kalshi_price)}&#162;{fee_str} &middot; {kalshi_edge}"
                     if kalshi_ticker:
                         kalshi_url = _esc(kalshi_event_url(kalshi_ticker))
                         kalshi_html = f'<div class="kalshi-row"><a href="{kalshi_url}" target="_blank" class="kalshi-link">{kalshi_text}</a></div>'
@@ -1321,7 +1321,7 @@ def _render_spread_bets(col, lg, position_lookup=None):
                     poly_fee = row.get('Poly_Fee')
                     poly_fee_str = f" + {_esc(poly_fee)}&#162; fee" if pd.notna(poly_fee) and poly_fee else ""
                     poly_ticker = row.get('Poly_Ticker', '')
-                    poly_text = f"Poly {_esc(row.get('Pick', ''))} @ {_esc(poly_price)}&#162;{poly_fee_str} ({_esc(poly_side)} side) &middot; {poly_edge}"
+                    poly_text = f"Poly: Buy {_esc(poly_side)} @ {_esc(poly_price)}&#162;{poly_fee_str} &middot; {poly_edge}"
                     if poly_ticker:
                         poly_url = _esc(polymarket_event_url(poly_ticker))
                         poly_html = f'<div class="poly-row"><a href="{poly_url}" target="_blank" class="poly-link">{poly_text}</a></div>'
@@ -1417,7 +1417,7 @@ def _render_game_bets(col, lg, position_lookup=None):
             game_fee_str = f" + {game_fee_val:.1f}&#162; fee" if game_fee_val else ""
             game_pick = _esc(row.get('Pick', ''))
             game_side = _esc(row.get('Kalshi_Side', ''))
-            game_kalshi_text = f"Kalshi {game_pick} @ {_esc(row.get('Kalshi_Price', ''))}&#162;{game_fee_str} ({game_side} side)"
+            game_kalshi_text = f"Kalshi: Buy {game_side} @ {_esc(row.get('Kalshi_Price', ''))}&#162;{game_fee_str}"
             game_kalshi_url = _esc(kalshi_event_url(game_kalshi_ticker))
             if game_kalshi_url:
                 game_kalshi_html = f'<a href="{game_kalshi_url}" target="_blank" class="kalshi-link">{game_kalshi_text}</a>'
@@ -1432,7 +1432,7 @@ def _render_game_bets(col, lg, position_lookup=None):
                 game_poly_fee = row.get('Poly_Fee')
                 game_poly_fee_str = f" + {float(game_poly_fee):.1f}&#162; fee" if pd.notna(game_poly_fee) and game_poly_fee else ""
                 game_poly_ticker = row.get('Poly_Ticker', '')
-                game_poly_text = f"Poly {game_pick} @ {_esc(row.get('Poly_Price', ''))}&#162;{game_poly_fee_str} ({_esc(game_poly_side)} side) &middot; {game_poly_edge}"
+                game_poly_text = f"Poly: Buy {_esc(game_poly_side)} @ {_esc(row.get('Poly_Price', ''))}&#162;{game_poly_fee_str} &middot; {game_poly_edge}"
                 if game_poly_ticker:
                     game_poly_url = _esc(polymarket_event_url(game_poly_ticker))
                     game_poly_html = f'<div class="poly-row"><a href="{game_poly_url}" target="_blank" class="poly-link">{game_poly_text}</a></div>'

--- a/betting/__init__.py
+++ b/betting/__init__.py
@@ -7,6 +7,9 @@ from .ev_calculator import (
     EdgeRating,
     analyze_bet,
     kalshi_implied_prob,
+    polymarket_implied_prob,
+    polymarket_fee_cents,
+    analyze_polymarket_bet,
     VALUE_RATINGS,
     RATING_RANK,
 )
@@ -36,5 +39,8 @@ __all__ = [
     "find_breakeven_spread",
     "format_line_shopping_text",
     "kalshi_implied_prob",
+    "polymarket_implied_prob",
+    "polymarket_fee_cents",
+    "analyze_polymarket_bet",
     "STANDARD_IMPLIED_PROB",
 ]

--- a/betting/ev_calculator.py
+++ b/betting/ev_calculator.py
@@ -177,3 +177,61 @@ def analyze_bet(model_prob: float, kalshi_yes_price: float) -> dict:
         "model_prob": model_prob,
         "ev": ev,
     }
+
+
+# -- Polymarket fee model --
+# Polymarket CLOB taker fee: rate * P * (1-P), same formula as Kalshi.
+# Sports markets: 3.0%, Crypto: 7.2%, Politics: 4.0%, Geopolitics: 0%.
+# https://docs.polymarket.com/trading/fees
+POLYMARKET_TAKER_FEE_COEFF = 0.03
+
+
+def polymarket_fee_cents(price_cents: float) -> float:
+    """Polymarket fee in cents for a single contract (currently 0)."""
+    p = price_cents / 100.0
+    return POLYMARKET_TAKER_FEE_COEFF * p * (1.0 - p) * 100.0
+
+
+def polymarket_implied_prob(price_cents: float) -> float:
+    """Convert Polymarket buy price to fee-adjusted implied probability.
+
+    Sports taker fee is 3% * P * (1-P), so breakeven probability
+    is (price + fee) / 100 -- same structure as Kalshi but cheaper.
+
+    Args:
+        price_cents: Polymarket buy price on 0-100 scale
+
+    Returns:
+        Fee-adjusted implied probability (0-1 scale)
+    """
+    p = price_cents / 100.0
+    fee = POLYMARKET_TAKER_FEE_COEFF * p * (1.0 - p)
+    return p + fee
+
+
+def analyze_polymarket_bet(model_prob: float, poly_yes_price: float) -> dict:
+    """Complete bet analysis for a Polymarket contract.
+
+    Args:
+        model_prob: Model's predicted probability (0-1)
+        poly_yes_price: Polymarket Yes price (0-100 scale)
+
+    Returns:
+        Dict with edge, edge_pct, rating, implied_prob, model_prob, ev
+    """
+    implied_prob = polymarket_implied_prob(poly_yes_price)
+    edge = calculate_edge(model_prob, implied_prob)
+    rating = get_rating(edge)
+
+    effective_cost = poly_yes_price + polymarket_fee_cents(poly_yes_price)
+    payout = (100 - effective_cost) / effective_cost if effective_cost > 0 else 0
+    ev = calculate_ev(model_prob, payout_if_win=payout, cost_if_loss=1.0)
+
+    return {
+        "edge": edge,
+        "edge_pct": edge * 100,
+        "rating": rating,
+        "implied_prob": implied_prob,
+        "model_prob": model_prob,
+        "ev": ev,
+    }

--- a/betting/ev_calculator.py
+++ b/betting/ev_calculator.py
@@ -187,7 +187,7 @@ POLYMARKET_TAKER_FEE_COEFF = 0.03
 
 
 def polymarket_fee_cents(price_cents: float) -> float:
-    """Polymarket fee in cents for a single contract (currently 0)."""
+    """Polymarket taker fee in cents for a single contract (3% sports rate)."""
     p = price_cents / 100.0
     return POLYMARKET_TAKER_FEE_COEFF * p * (1.0 - p) * 100.0
 

--- a/grade_predictions.py
+++ b/grade_predictions.py
@@ -88,15 +88,35 @@ def fetch_completed_games(date_obj, league="mens"):
                         f"for {away_name} @ {home_name}"
                     )
             
-            # Store with multiple key formats for easier matching
+            # Extract game start time in Eastern for doubleheader disambiguation.
+            # ESPN returns UTC; predictions display Eastern -- must match.
+            game_start = event.get("date", "")
+            game_time_str = ""
+            if game_start:
+                try:
+                    from datetime import datetime as _dt, timezone as _tz
+                    import pytz as _pytz
+                    gdt = _dt.fromisoformat(game_start.replace("Z", "+00:00"))
+                    eastern = _pytz.timezone("US/Eastern")
+                    gdt_eastern = gdt.astimezone(eastern)
+                    game_time_str = gdt_eastern.strftime("%H:%M")
+                except (ValueError, TypeError, ImportError):
+                    pass
+
             game_key = (home_name, away_name)
-            games[game_key] = {
+            game_data = {
                 'home_score': home_score,
                 'away_score': away_score,
                 'spread': spread,
                 'home_name': home_name,
-                'away_name': away_name
+                'away_name': away_name,
+                'game_time': game_time_str,
             }
+            # Handle doubleheaders: if key exists, use (home, away, N)
+            if game_key in games:
+                games[(home_name, away_name, 2)] = game_data
+            else:
+                games[game_key] = game_data
             
         print(f"      Found {len(games)} completed games")
         return games
@@ -108,31 +128,59 @@ def fetch_completed_games(date_obj, league="mens"):
         print(f"      ESPN fetch/parse error: {e}")
         return {}
 
-def match_prediction_to_game(pred_matchup, games):
+def match_prediction_to_game(pred_matchup, games, pred_time=""):
     """
     Try to match a prediction matchup to an actual game.
     pred_matchup format: "Away @ Home"
+    pred_time: optional "HH:MM" to disambiguate doubleheaders
     """
     # Parse prediction matchup
     parts = pred_matchup.split(' @ ')
     if len(parts) != 2:
         return None
-    
+
     pred_away, pred_home = parts
-    
-    # Try exact match first
-    for (game_home, game_away), result in games.items():
+
+    def _is_match(game_home, game_away):
+        # Exact match
         if game_home == pred_home and game_away == pred_away:
-            return result
-    
-    # Try fuzzy matching
-    for (game_home, game_away), result in games.items():
-        # Check if key parts of names match
+            return True
+        # Fuzzy match
         if (pred_home in game_home or game_home in pred_home) and \
            (pred_away in game_away or game_away in pred_away):
-            return result
-    
-    return None
+            return True
+        return False
+
+    # Collect all matching games (may be >1 for doubleheaders)
+    matches = []
+    for key, result in games.items():
+        # Keys are (home, away) or (home, away, game_number)
+        game_home = key[0]
+        game_away = key[1]
+        if _is_match(game_home, game_away):
+            matches.append(result)
+
+    if not matches:
+        return None
+    if len(matches) == 1:
+        return matches[0]
+
+    # Doubleheader: pick the game closest to pred_time
+    if pred_time:
+        try:
+            pred_parts = pred_time.replace(":", "")[:4]
+            pred_min = int(pred_parts[:2]) * 60 + int(pred_parts[2:4])
+            def _time_dist(g):
+                gt = g.get("game_time", "")
+                if not gt:
+                    return 9999
+                gp = gt.replace(":", "")[:4]
+                return abs(int(gp[:2]) * 60 + int(gp[2:4]) - pred_min)
+            return min(matches, key=_time_dist)
+        except (ValueError, IndexError):
+            pass
+
+    return matches[0]
 
 def grade_pick(pick_str, spread, home_score, away_score, matchup):
     """
@@ -318,8 +366,31 @@ def grade_predictions(league="mens"):
             pred_spread = 0.0
         bet_type = str(pred.get("Bet_Type", "spread") or "spread").strip().lower()
         
+        # Extract game time from prediction for doubleheader disambiguation.
+        # Both game_time (from ESPN) and pred_time are stored as Eastern.
+        # CBB format "04/09 07:00 PM" is already Eastern (from tz_convert).
+        # MLB format "2026-04-09 16:10" is UTC -- convert to Eastern.
+        pred_time_str = ""
+        raw_dt = pred.get("Date/Time", "")
+        if raw_dt and isinstance(raw_dt, str) and ":" in raw_dt:
+            try:
+                if "-" in raw_dt:
+                    # ISO-ish: "2026-04-09 16:10" (UTC from mlb/predict.py)
+                    from datetime import datetime as _dt, timezone as _tz
+                    import pytz as _pytz
+                    utc_dt = _dt.strptime(raw_dt.strip(), "%Y-%m-%d %H:%M").replace(tzinfo=_tz.utc)
+                    eastern = _pytz.timezone("US/Eastern")
+                    pred_time_str = utc_dt.astimezone(eastern).strftime("%H:%M")
+                else:
+                    # "04/09 07:00 PM" (already Eastern from CBB predict.py)
+                    from datetime import datetime as _dt
+                    dt = _dt.strptime(raw_dt.strip(), "%m/%d %I:%M %p")
+                    pred_time_str = dt.strftime("%H:%M")
+            except (ValueError, IndexError):
+                pass
+
         # Find the corresponding game
-        game_result = match_prediction_to_game(matchup, completed_games)
+        game_result = match_prediction_to_game(matchup, completed_games, pred_time=pred_time_str)
         
         if game_result is None:
             # Couldn't find this game - might be for today/tomorrow

--- a/grade_predictions.py
+++ b/grade_predictions.py
@@ -311,9 +311,10 @@ def grade_predictions(league="mens"):
         # Filter for actionable bets only (value-rated from either source)
         has_std = 'Std_Rating' in preds.columns
         has_kalshi = 'Rating' in preds.columns
+        has_poly = 'Poly_Rating' in preds.columns
 
-        if not has_std and not has_kalshi:
-            print("ERROR: Prediction file has neither 'Std_Rating' nor 'Rating' column.")
+        if not has_std and not has_kalshi and not has_poly:
+            print("ERROR: Prediction file has no rating columns.")
             print("   Cannot determine which bets are actionable.")
             print(f"   Columns found: {list(preds.columns)}")
             print("   Re-run predict.py to generate a file with rating columns.")
@@ -321,8 +322,11 @@ def grade_predictions(league="mens"):
 
         std_rating = preds['Std_Rating'] if has_std else pd.Series('PASS', index=preds.index)
         kalshi_rating = preds['Rating'].fillna('PASS') if has_kalshi else pd.Series('PASS', index=preds.index)
+        poly_rating = preds['Poly_Rating'].fillna('PASS') if has_poly else pd.Series('PASS', index=preds.index)
         preds = preds[
-            (std_rating.isin(VALUE_RATINGS)) | (kalshi_rating.isin(VALUE_RATINGS))
+            (std_rating.isin(VALUE_RATINGS)) |
+            (kalshi_rating.isin(VALUE_RATINGS)) |
+            (poly_rating.isin(VALUE_RATINGS))
         ].copy()
 
         print(f"   Filtered to {len(preds)} actionable bets (value-rated)")

--- a/mlb/predict.py
+++ b/mlb/predict.py
@@ -25,10 +25,11 @@ from betting import (
     get_rating,
     recommended_units,
     kalshi_implied_prob,
+    polymarket_implied_prob,
     EdgeRating,
     VALUE_RATINGS,
 )
-from betting.ev_calculator import kalshi_fee_cents
+from betting.ev_calculator import kalshi_fee_cents, polymarket_fee_cents
 from league_config import (
     get_league_artifact_paths,
     get_scoreboard_base_url,
@@ -507,6 +508,96 @@ def _get_kalshi_edge(client, mapper, home_team, away_team, game_date,
     return result
 
 
+def _get_polymarket_edge(client, mapper, home_team, away_team, game_date,
+                         prob_home_win, pick, game_time=""):
+    """Calculate edge against Polymarket GAME market prices.
+
+    Mirrors _get_kalshi_edge but uses Polymarket fee model and passes
+    game_time for doubleheader disambiguation.
+    """
+    result = {
+        "Poly_Ticker": None,
+        "Poly_Side": None,
+        "Poly_Price": None,
+        "Poly_Fee": None,
+        "Poly_Edge": None,
+        "Poly_Edge_Pct": None,
+        "Poly_Rating": EdgeRating.PASS.value,
+        "Poly_Units": None,
+    }
+
+    if not mapper or not client:
+        return result
+
+    try:
+        market = mapper.find_game_market(
+            home_team, away_team, game_date, game_time=game_time,
+        )
+    except Exception as e:
+        print(f"      Polymarket market lookup error for {away_team} @ {home_team}: {e}")
+        return result
+
+    if not market:
+        return result
+
+    prices = mapper.get_market_prices(market)
+    token_id = prices.get("token_id")
+    title = prices.get("title", "")
+
+    # Try live prices
+    if token_id:
+        try:
+            live = client.get_market_prices(token_id, title=title)
+            if live.get("yes_price") is not None:
+                prices = live
+        except Exception:
+            pass
+
+    yes_price = prices.get("yes_price")
+    no_price = prices.get("no_price")
+    if yes_price is None:
+        return result
+
+    yes_team = mapper.infer_yes_team(market, home_team, away_team)
+    if not yes_team:
+        return result
+
+    # Determine our side
+    if pick == yes_team:
+        our_price = yes_price
+        our_side = "YES"
+    else:
+        our_price = no_price if no_price else (100 - yes_price)
+        our_side = "NO"
+
+    if our_price is None or our_price <= 0:
+        return result
+
+    model_prob = prob_home_win if pick == home_team else (1.0 - prob_home_win)
+    implied_prob = polymarket_implied_prob(our_price)
+    fee = polymarket_fee_cents(our_price) / 100.0
+
+    raw_edge = calculate_edge(model_prob, implied_prob)
+    edge = min(raw_edge, KALSHI_EDGE_CAP)
+    rating = _get_kalshi_game_rating(edge, model_prob, our_price)
+    units = (
+        recommended_units(edge, implied_prob)
+        if rating in VALUE_RATINGS
+        else 0.0
+    )
+
+    result["Poly_Ticker"] = token_id
+    result["Poly_Side"] = our_side
+    result["Poly_Price"] = our_price
+    result["Poly_Fee"] = round(fee, 4)
+    result["Poly_Edge"] = round(edge, 4)
+    result["Poly_Edge_Pct"] = f"{edge * 100:+.1f}%"
+    result["Poly_Rating"] = rating
+    result["Poly_Units"] = min(units, 0.5)
+
+    return result
+
+
 def generate_predictions(league=LEAGUE):
     """Generate daily MLB predictions."""
     league = normalize_league(league)
@@ -555,6 +646,24 @@ def generate_predictions(league=LEAGUE):
         except requests.RequestException as e:
             print(f"   Kalshi: API error loading markets: {e}")
 
+    poly_client = None
+    poly_mapper = None
+    proxy = os.environ.get("POLYMARKET_PROXY")
+    if not proxy:
+        print("   Polymarket: POLYMARKET_PROXY not set, skipping")
+    else:
+        try:
+            from polymarket import PolymarketClient, PolymarketMarketMapper
+            poly_client = PolymarketClient(proxy_url=proxy)
+            poly_markets = poly_client.get_sports_markets("MLB")
+            if poly_markets:
+                poly_mapper = PolymarketMarketMapper(poly_markets)
+                print(f"   Polymarket: {len(poly_markets)} MLB markets loaded")
+            else:
+                print("   Polymarket: no MLB markets found")
+        except Exception as e:
+            print(f"   Polymarket: error loading markets: {e}")
+
     # Fetch schedule
     games = fetch_schedule(league)
     if not games:
@@ -591,10 +700,17 @@ def generate_predictions(league=LEAGUE):
         conf = max(prob_home_win, prob_away_win)
         pick = game["home_team"] if prob_home_win > 0.5 else game["away_team"]
 
-        # Kalshi edge calculation -- pass game_time for doubleheader disambiguation
+        # Market edge calculations -- pass game_time for doubleheader disambiguation
         game_time_utc = game["game_date"].strftime("%H:%M") if hasattr(game["game_date"], "strftime") else ""
         kalshi_data = _get_kalshi_edge(
             kalshi_client, kalshi_mapper,
+            game["home_team"], game["away_team"],
+            game["game_date"],
+            prob_home_win, pick,
+            game_time=game_time_utc,
+        )
+        poly_data = _get_polymarket_edge(
+            poly_client, poly_mapper,
             game["home_team"], game["away_team"],
             game["game_date"],
             prob_home_win, pick,
@@ -631,6 +747,7 @@ def generate_predictions(league=LEAGUE):
             "Std_Units": round(std_units, 1),
             "Std_Odds": ml_odds_str or "",
             **kalshi_data,
+            **poly_data,
         }
         predictions.append(pred)
 
@@ -644,6 +761,12 @@ def generate_predictions(league=LEAGUE):
             print(f"      Kalshi: Buy {side} @ {kalshi_data['Kalshi_Price']}c"
                   f" + {k_fee:.1f}c fee | Edge: {kalshi_data['Edge_Pct']}"
                   f" | {kalshi_data['Units']:.1f}U")
+        if poly_data.get("Poly_Rating") in VALUE_RATINGS:
+            p_side = poly_data.get("Poly_Side", "?")
+            p_fee = poly_data.get("Poly_Fee", 0) or 0
+            print(f"      Poly: Buy {p_side} @ {poly_data['Poly_Price']}c"
+                  f" + {p_fee:.1f}c fee | Edge: {poly_data['Poly_Edge_Pct']}"
+                  f" | {poly_data['Poly_Units']:.1f}U")
         if std_rating in VALUE_RATINGS:
             print(f"      DK: Edge {pred['Std_Edge_Pct']}"
                   f" | {std_units:.1f}U")

--- a/mlb/predict.py
+++ b/mlb/predict.py
@@ -545,12 +545,14 @@ def _get_polymarket_edge(client, mapper, home_team, away_team, game_date,
     no_token_id = prices.get("no_token_id")
     title = prices.get("title", "")
 
-    # Try live prices -- fetch YES and NO tokens independently
+    # Try live prices -- merge selectively so cached values survive
     if token_id:
         try:
             live = client.get_market_prices(token_id, title=title, no_token_id=no_token_id)
             if live.get("yes_price") is not None:
-                prices = live
+                prices["yes_price"] = live["yes_price"]
+            if live.get("no_price") is not None:
+                prices["no_price"] = live["no_price"]
         except (requests.RequestException, ValueError, KeyError) as e:
             print(f"      Polymarket live price fetch failed for {token_id}: {e}")
 

--- a/mlb/predict.py
+++ b/mlb/predict.py
@@ -627,45 +627,51 @@ def generate_predictions(league=LEAGUE):
     known_teams = set(latest_stats.keys())
     print(f"   Stats loaded for {len(known_teams)} teams, {len(pitcher_stats)} pitchers")
 
-    # Fetch Kalshi markets
-    kalshi_client = None
-    kalshi_mapper = None
-    api_key = os.environ.get("KALSHI_API_KEY")
-    if not api_key:
-        print("   Kalshi: KALSHI_API_KEY not set, skipping")
-    else:
+    # Fetch schedule + market data in parallel
+    def _fetch_kalshi():
+        api_key = os.environ.get("KALSHI_API_KEY")
+        if not api_key:
+            print("   Kalshi: KALSHI_API_KEY not set, skipping")
+            return None, None
         from kalshi import KalshiClient, MLBMarketMapper
-        kalshi_client = KalshiClient(api_key)
+        client = KalshiClient(api_key)
         try:
-            markets = kalshi_client.get_mlb_markets()
+            markets = client.get_mlb_markets()
             if markets:
-                kalshi_mapper = MLBMarketMapper(markets)
                 print(f"   Kalshi: {len(markets)} MLB markets loaded")
-            else:
-                print("   Kalshi: no MLB markets found")
+                return client, MLBMarketMapper(markets)
+            print("   Kalshi: no MLB markets found")
+            return client, None
         except requests.RequestException as e:
             print(f"   Kalshi: API error loading markets: {e}")
+            return None, None
 
-    poly_client = None
-    poly_mapper = None
-    proxy = os.environ.get("POLYMARKET_PROXY")
-    if not proxy:
-        print("   Polymarket: POLYMARKET_PROXY not set, skipping")
-    else:
+    def _fetch_poly():
+        proxy = os.environ.get("POLYMARKET_PROXY")
+        if not proxy:
+            print("   Polymarket: POLYMARKET_PROXY not set, skipping")
+            return None, None
         try:
             from polymarket import PolymarketClient, PolymarketMarketMapper
-            poly_client = PolymarketClient(proxy_url=proxy)
-            poly_markets = poly_client.get_sports_game_markets("MLB")
-            if poly_markets:
-                poly_mapper = PolymarketMarketMapper(poly_markets)
-                print(f"   Polymarket: {len(poly_markets)} MLB markets loaded")
-            else:
-                print("   Polymarket: no MLB markets found")
+            client = PolymarketClient(proxy_url=proxy)
+            markets = client.get_sports_game_markets("MLB")
+            if markets:
+                print(f"   Polymarket: {len(markets)} MLB markets loaded")
+                return client, PolymarketMarketMapper(markets)
+            print("   Polymarket: no MLB markets found")
+            return client, None
         except Exception as e:
             print(f"   Polymarket: error loading markets: {e}")
+            return None, None
 
-    # Fetch schedule
-    games = fetch_schedule(league)
+    with ThreadPoolExecutor(max_workers=3) as pool:
+        _sched_f = pool.submit(fetch_schedule, league)
+        _kalshi_f = pool.submit(_fetch_kalshi)
+        _poly_f = pool.submit(_fetch_poly)
+
+        games = _sched_f.result()
+        kalshi_client, kalshi_mapper = _kalshi_f.result()
+        poly_client, poly_mapper = _poly_f.result()
     if not games:
         print("   No upcoming games found.")
         return []

--- a/mlb/predict.py
+++ b/mlb/predict.py
@@ -542,12 +542,13 @@ def _get_polymarket_edge(client, mapper, home_team, away_team, game_date,
 
     prices = mapper.get_market_prices(market)
     token_id = prices.get("token_id")
+    no_token_id = prices.get("no_token_id")
     title = prices.get("title", "")
 
-    # Try live prices
+    # Try live prices -- fetch YES and NO tokens independently
     if token_id:
         try:
-            live = client.get_market_prices(token_id, title=title)
+            live = client.get_market_prices(token_id, title=title, no_token_id=no_token_id)
             if live.get("yes_price") is not None:
                 prices = live
         except (requests.RequestException, ValueError, KeyError) as e:

--- a/mlb/predict.py
+++ b/mlb/predict.py
@@ -655,7 +655,7 @@ def generate_predictions(league=LEAGUE):
         try:
             from polymarket import PolymarketClient, PolymarketMarketMapper
             poly_client = PolymarketClient(proxy_url=proxy)
-            poly_markets = poly_client.get_sports_markets("MLB")
+            poly_markets = poly_client.get_sports_game_markets("MLB")
             if poly_markets:
                 poly_mapper = PolymarketMarketMapper(poly_markets)
                 print(f"   Polymarket: {len(poly_markets)} MLB markets loaded")

--- a/mlb/predict.py
+++ b/mlb/predict.py
@@ -550,8 +550,8 @@ def _get_polymarket_edge(client, mapper, home_team, away_team, game_date,
             live = client.get_market_prices(token_id, title=title)
             if live.get("yes_price") is not None:
                 prices = live
-        except Exception:
-            pass
+        except (requests.RequestException, ValueError, KeyError) as e:
+            print(f"      Polymarket live price fetch failed for {token_id}: {e}")
 
     yes_price = prices.get("yes_price")
     no_price = prices.get("no_price")

--- a/polymarket/__init__.py
+++ b/polymarket/__init__.py
@@ -1,4 +1,4 @@
-"""Polymarket prediction market integration via CLI."""
+"""Polymarket prediction market integration via Gamma API."""
 
 from .client import PolymarketClient
 from .market_mapper import PolymarketMarketMapper

--- a/polymarket/__init__.py
+++ b/polymarket/__init__.py
@@ -1,0 +1,6 @@
+"""Polymarket prediction market integration via CLI."""
+
+from .client import PolymarketClient
+from .market_mapper import PolymarketMarketMapper
+
+__all__ = ["PolymarketClient", "PolymarketMarketMapper"]

--- a/polymarket/client.py
+++ b/polymarket/client.py
@@ -1,0 +1,215 @@
+"""Polymarket API client wrapping the polymarket CLI binary."""
+
+import json
+import os
+import subprocess
+from typing import Optional
+
+
+class PolymarketClient:
+    """Client that wraps the Polymarket CLI for market data access.
+
+    All HTTP requests are routed through a proxy (required for US users)
+    by setting HTTPS_PROXY/HTTP_PROXY/ALL_PROXY in the subprocess env.
+    """
+
+    def __init__(
+        self,
+        cli_path: Optional[str] = None,
+        proxy_url: Optional[str] = None,
+        timeout: int = 30,
+    ):
+        self.cli_path = cli_path or os.getenv("POLYMARKET_CLI_PATH", "polymarket")
+        self.proxy_url = proxy_url or os.getenv("POLYMARKET_PROXY")
+        self.timeout = timeout
+
+    def _run_cli(self, args: list[str]) -> dict | list:
+        """Execute a polymarket CLI command and return parsed JSON.
+
+        Prepends ``-o json`` so every command emits machine-readable output.
+        Proxy env vars are injected into the subprocess environment.
+
+        Returns ``{}`` (for object commands) or ``[]`` (for list commands)
+        on any failure.
+        """
+        cmd = [self.cli_path, "-o", "json"] + args
+
+        env = os.environ.copy()
+        if self.proxy_url:
+            env["HTTPS_PROXY"] = self.proxy_url
+            env["HTTP_PROXY"] = self.proxy_url
+            env["ALL_PROXY"] = self.proxy_url
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+                env=env,
+            )
+            if result.returncode != 0:
+                stderr = result.stderr.strip()
+                if stderr:
+                    print(f"      Polymarket CLI error: {stderr}")
+                return [] if not result.stdout.strip() else {}
+
+            stdout = result.stdout.strip()
+            if not stdout:
+                return []
+
+            return json.loads(stdout)
+
+        except FileNotFoundError:
+            print("      Polymarket CLI not found. Install: brew tap Polymarket/polymarket-cli https://github.com/Polymarket/polymarket-cli && brew install polymarket")
+            return []
+        except subprocess.TimeoutExpired:
+            print(f"      Polymarket CLI timed out after {self.timeout}s")
+            return []
+        except json.JSONDecodeError as e:
+            print(f"      Polymarket CLI returned invalid JSON: {e}")
+            return []
+
+    # -- Read-only market browsing (no wallet needed) --
+
+    def search_markets(self, query: str, limit: int = 50) -> list[dict]:
+        """Search markets by text query."""
+        return self._run_cli(["markets", "search", query, "--limit", str(limit)])
+
+    def list_events(
+        self,
+        tag: Optional[str] = None,
+        active: bool = True,
+        limit: int = 50,
+    ) -> list[dict]:
+        """List events, optionally filtered by tag."""
+        args = ["events", "list", "--limit", str(limit)]
+        if tag:
+            args += ["--tag", tag]
+        if active:
+            args += ["--active", "true"]
+        return self._run_cli(args)
+
+    def get_market(self, id_or_slug: str) -> dict:
+        """Get a single market by numeric ID or slug."""
+        result = self._run_cli(["markets", "get", str(id_or_slug)])
+        return result if isinstance(result, dict) else {}
+
+    def get_sports_markets(self, league: str, limit: int = 100) -> list[dict]:
+        """List sports markets for a league (e.g. 'NCAAB', 'MLB', 'NBA')."""
+        result = self._run_cli(
+            ["sports", "list", "--league", league, "--limit", str(limit)]
+        )
+        return result if isinstance(result, list) else []
+
+    def get_sports_market_types(self) -> list[dict]:
+        """List available sports market types (moneyline, spread, total)."""
+        result = self._run_cli(["sports", "market-types"])
+        return result if isinstance(result, list) else []
+
+    def get_sports_teams(self, league: str, limit: int = 100) -> list[dict]:
+        """List teams for a league."""
+        result = self._run_cli(
+            ["sports", "teams", "--league", league, "--limit", str(limit)]
+        )
+        return result if isinstance(result, list) else []
+
+    # -- CLOB price data (no wallet needed) --
+
+    def get_midpoint(self, token_id: str) -> Optional[float]:
+        """Get midpoint price for a token (0-1 scale)."""
+        result = self._run_cli(["clob", "midpoint", token_id])
+        if isinstance(result, dict):
+            mid = result.get("mid") or result.get("midpoint")
+            if mid is not None:
+                return float(mid)
+        return None
+
+    def get_price(self, token_id: str, side: str = "buy") -> Optional[float]:
+        """Get buy or sell price for a token (0-1 scale)."""
+        result = self._run_cli(["clob", "price", token_id, "--side", side])
+        if isinstance(result, dict):
+            price = result.get("price")
+            if price is not None:
+                return float(price)
+        return None
+
+    def get_spread(self, token_id: str) -> Optional[dict]:
+        """Get bid-ask spread for a token."""
+        result = self._run_cli(["clob", "spread", token_id])
+        return result if isinstance(result, dict) else None
+
+    def get_book(self, token_id: str) -> dict:
+        """Get full order book for a token."""
+        result = self._run_cli(["clob", "book", token_id])
+        return result if isinstance(result, dict) else {}
+
+    def get_fee_rate(self, token_id: str) -> Optional[float]:
+        """Get fee rate for a token."""
+        result = self._run_cli(["clob", "fee-rate", token_id])
+        if isinstance(result, dict):
+            rate = result.get("fee_rate") or result.get("feeRate")
+            if rate is not None:
+                return float(rate)
+        return None
+
+    # -- Market price helpers --
+
+    def get_market_prices(self, token_id: str, title: str = "") -> dict:
+        """Get YES/NO prices normalized to 0-100 cent scale.
+
+        Polymarket native prices are 0-1 (probability). We multiply by 100
+        to match the Kalshi convention used in ev_calculator.py.
+        """
+        mid = self.get_midpoint(token_id)
+        if mid is not None:
+            yes_price = round(mid * 100.0, 2)
+            no_price = round(100.0 - yes_price, 2)
+        else:
+            buy = self.get_price(token_id, "buy")
+            if buy is not None:
+                yes_price = round(buy * 100.0, 2)
+                no_price = round(100.0 - yes_price, 2)
+            else:
+                yes_price = None
+                no_price = None
+
+        return {
+            "yes_price": yes_price,
+            "no_price": no_price,
+            "token_id": token_id,
+            "title": title,
+        }
+
+    # -- Position/portfolio data (wallet address, public) --
+
+    def get_positions(self, wallet_address: str) -> list[dict]:
+        """Get open positions for a wallet address."""
+        result = self._run_cli(["data", "positions", wallet_address])
+        return result if isinstance(result, list) else []
+
+    def get_closed_positions(self, wallet_address: str) -> list[dict]:
+        """Get closed/settled positions for a wallet address."""
+        result = self._run_cli(["data", "closed-positions", wallet_address])
+        return result if isinstance(result, list) else []
+
+    def get_trades(self, wallet_address: str, limit: int = 50) -> list[dict]:
+        """Get recent trades for a wallet address."""
+        result = self._run_cli(
+            ["data", "trades", wallet_address, "--limit", str(limit)]
+        )
+        return result if isinstance(result, list) else []
+
+    # -- Connectivity check --
+
+    def check_geoblock(self) -> dict:
+        """Check if the current connection is geoblocked."""
+        result = self._run_cli(["clob", "geoblock"])
+        return result if isinstance(result, dict) else {}
+
+    def is_ok(self) -> bool:
+        """Check if the CLOB API is reachable."""
+        result = self._run_cli(["clob", "ok"])
+        if isinstance(result, dict):
+            return result.get("ok", False) or result.get("status") == "ok"
+        return False

--- a/polymarket/client.py
+++ b/polymarket/client.py
@@ -29,6 +29,7 @@ SPORT_TAG_IDS = {
 
 GAMMA_BASE = "https://gamma-api.polymarket.com"
 CLOB_BASE = "https://clob.polymarket.com"
+DATA_BASE = "https://data-api.polymarket.com"
 
 
 class PolymarketClient:
@@ -162,47 +163,69 @@ class PolymarketClient:
 
     # -- Market price helpers --
 
-    def get_market_prices(self, token_id: str, title: str = "") -> dict:
+    def get_market_prices(
+        self,
+        yes_token_id: str,
+        title: str = "",
+        no_token_id: Optional[str] = None,
+    ) -> dict:
         """Get YES/NO prices normalized to 0-100 cent scale.
+
+        Polymarket markets have distinct YES and NO token IDs, each with
+        their own order book. When ``no_token_id`` is provided, the NO
+        price is fetched independently (not complemented from YES).
 
         Polymarket native prices are 0-1 (probability). We multiply by 100
         to match the Kalshi convention used in ev_calculator.py.
         """
-        mid = self.get_midpoint(token_id)
+        # Fetch YES price
+        yes_price = None
+        mid = self.get_midpoint(yes_token_id)
         if mid is not None:
             yes_price = round(mid * 100.0, 2)
-            no_price = round(100.0 - yes_price, 2)
         else:
-            buy = self.get_price(token_id, "BUY")
+            buy = self.get_price(yes_token_id, "BUY")
             if buy is not None:
                 yes_price = round(buy * 100.0, 2)
-                no_price = round(100.0 - yes_price, 2)
+
+        # Fetch NO price from its own token (independent order book)
+        no_price = None
+        if no_token_id:
+            no_mid = self.get_midpoint(no_token_id)
+            if no_mid is not None:
+                no_price = round(no_mid * 100.0, 2)
             else:
-                yes_price = None
-                no_price = None
+                no_buy = self.get_price(no_token_id, "BUY")
+                if no_buy is not None:
+                    no_price = round(no_buy * 100.0, 2)
+
+        # Fallback: complement from YES if NO token wasn't provided
+        if no_price is None and yes_price is not None and not no_token_id:
+            no_price = round(100.0 - yes_price, 2)
 
         return {
             "yes_price": yes_price,
             "no_price": no_price,
-            "token_id": token_id,
+            "token_id": yes_token_id,
             "title": title,
         }
 
-    # -- Position/portfolio data (public, by wallet address) --
+    # -- Position/portfolio data (Data API, public by wallet address) --
+    # https://docs.polymarket.com/api-reference/core/get-closed-positions-for-a-user
 
     def get_positions(self, wallet_address: str) -> list[dict]:
         """Get open positions for a wallet address."""
         result = self._get(
-            f"{GAMMA_BASE}/data/positions",
-            {"address": wallet_address},
+            f"{DATA_BASE}/positions",
+            {"user": wallet_address},
         )
         return result if isinstance(result, list) else []
 
     def get_closed_positions(self, wallet_address: str) -> list[dict]:
         """Get closed/settled positions for a wallet address."""
         result = self._get(
-            f"{GAMMA_BASE}/data/closed-positions",
-            {"address": wallet_address},
+            f"{DATA_BASE}/closed-positions",
+            {"user": wallet_address},
         )
         return result if isinstance(result, list) else []
 

--- a/polymarket/client.py
+++ b/polymarket/client.py
@@ -1,157 +1,164 @@
-"""Polymarket API client wrapping the polymarket CLI binary."""
+"""Polymarket API client using the Gamma REST API with SOCKS5 proxy support.
+
+All sports per-game markets (moneyline, spread, total) are served by the
+Gamma API at https://gamma-api.polymarket.com. CLOB price data comes from
+https://clob.polymarket.com.
+
+Geo-restricted access is routed through a SOCKS5 proxy (SSH tunnel to a
+non-blocked region). Requires ``requests[socks]`` (PySocks).
+"""
 
 import json
 import os
-import subprocess
 from typing import Optional
+
+import requests
+
+
+# Sports tag IDs discovered from /sports endpoint.
+# MLB tags='1,100639,100381' -> tag 100381 is MLB-specific.
+# NCAAB tags='1,100149,100639' -> tag 100149 is NCAAB-specific.
+SPORT_TAG_IDS = {
+    "MLB": "100381",
+    "NCAAB": "100149",
+    "NBA": "10345",
+    "NFL": "10187",
+    "NHL": "10346",
+    "WNBA": "10105",
+}
+
+GAMMA_BASE = "https://gamma-api.polymarket.com"
+CLOB_BASE = "https://clob.polymarket.com"
 
 
 class PolymarketClient:
-    """Client that wraps the Polymarket CLI for market data access.
-
-    All HTTP requests are routed through a proxy (required for US users)
-    by setting HTTPS_PROXY/HTTP_PROXY/ALL_PROXY in the subprocess env.
-    """
+    """Client for Polymarket Gamma + CLOB APIs with SOCKS5 proxy support."""
 
     def __init__(
         self,
-        cli_path: Optional[str] = None,
         proxy_url: Optional[str] = None,
-        timeout: int = 30,
+        timeout: int = 15,
     ):
-        self.cli_path = cli_path or os.getenv("POLYMARKET_CLI_PATH", "polymarket")
         self.proxy_url = proxy_url or os.getenv("POLYMARKET_PROXY")
         self.timeout = timeout
-
-    def _run_cli(self, args: list[str]) -> dict | list:
-        """Execute a polymarket CLI command and return parsed JSON.
-
-        Prepends ``-o json`` so every command emits machine-readable output.
-        Proxy env vars are injected into the subprocess environment.
-
-        Returns ``{}`` (for object commands) or ``[]`` (for list commands)
-        on any failure.
-        """
-        cmd = [self.cli_path, "-o", "json"] + args
-
-        env = os.environ.copy()
+        self.session = requests.Session()
         if self.proxy_url:
-            env["HTTPS_PROXY"] = self.proxy_url
-            env["HTTP_PROXY"] = self.proxy_url
-            env["ALL_PROXY"] = self.proxy_url
+            self.session.proxies = {
+                "https": self.proxy_url,
+                "http": self.proxy_url,
+            }
 
+    def _get(self, url: str, params: Optional[dict] = None) -> dict | list:
+        """GET request with proxy routing and error handling."""
         try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=self.timeout,
-                env=env,
-            )
-            if result.returncode != 0:
-                stderr = result.stderr.strip()
-                if stderr:
-                    print(f"      Polymarket CLI error: {stderr}")
-                return [] if not result.stdout.strip() else {}
-
-            stdout = result.stdout.strip()
-            if not stdout:
-                return []
-
-            return json.loads(stdout)
-
-        except FileNotFoundError:
-            print("      Polymarket CLI not found. Install: brew tap Polymarket/polymarket-cli https://github.com/Polymarket/polymarket-cli && brew install polymarket")
-            return []
-        except subprocess.TimeoutExpired:
-            print(f"      Polymarket CLI timed out after {self.timeout}s")
-            return []
-        except json.JSONDecodeError as e:
-            print(f"      Polymarket CLI returned invalid JSON: {e}")
+            r = self.session.get(url, params=params, timeout=self.timeout)
+            r.raise_for_status()
+            return r.json()
+        except (requests.RequestException, json.JSONDecodeError, ValueError) as e:
+            print(f"      Polymarket API error: {e}")
             return []
 
-    # -- Read-only market browsing (no wallet needed) --
+    # -- Sports metadata --
 
-    def search_markets(self, query: str, limit: int = 50) -> list[dict]:
-        """Search markets by text query."""
-        return self._run_cli(["markets", "search", query, "--limit", str(limit)])
+    def get_sports(self) -> list[dict]:
+        """List all supported sports with IDs and series info."""
+        return self._get(f"{GAMMA_BASE}/sports")
 
-    def list_events(
+    def get_sports_market_types(self) -> dict:
+        """List valid sports market types."""
+        return self._get(f"{GAMMA_BASE}/sports/market-types")
+
+    # -- Events and markets --
+
+    def get_events(
         self,
-        tag: Optional[str] = None,
+        tag_id: Optional[str] = None,
         active: bool = True,
+        closed: bool = False,
         limit: int = 50,
     ) -> list[dict]:
-        """List events, optionally filtered by tag."""
-        args = ["events", "list", "--limit", str(limit)]
-        if tag:
-            args += ["--tag", tag]
+        """Fetch events from Gamma API, optionally filtered by tag."""
+        params = {"limit": str(limit)}
+        if tag_id:
+            params["tag_id"] = tag_id
         if active:
-            args += ["--active", "true"]
-        return self._run_cli(args)
-
-    def get_market(self, id_or_slug: str) -> dict:
-        """Get a single market by numeric ID or slug."""
-        result = self._run_cli(["markets", "get", str(id_or_slug)])
-        return result if isinstance(result, dict) else {}
-
-    def get_sports_markets(self, league: str, limit: int = 100) -> list[dict]:
-        """List sports markets for a league (e.g. 'NCAAB', 'MLB', 'NBA')."""
-        result = self._run_cli(
-            ["sports", "list", "--league", league, "--limit", str(limit)]
-        )
+            params["active"] = "true"
+        if not closed:
+            params["closed"] = "false"
+        result = self._get(f"{GAMMA_BASE}/events", params)
         return result if isinstance(result, list) else []
 
-    def get_sports_market_types(self) -> list[dict]:
-        """List available sports market types (moneyline, spread, total)."""
-        result = self._run_cli(["sports", "market-types"])
-        return result if isinstance(result, list) else []
+    def get_sports_events(self, league: str, limit: int = 50) -> list[dict]:
+        """Fetch per-game sports events for a league.
 
-    def get_sports_teams(self, league: str, limit: int = 100) -> list[dict]:
-        """List teams for a league."""
-        result = self._run_cli(
-            ["sports", "teams", "--league", league, "--limit", str(limit)]
-        )
-        return result if isinstance(result, list) else []
+        Uses the sport-specific tag ID to filter. Returns events with
+        nested ``markets`` arrays containing moneyline, spread, and total
+        markets.
+        """
+        tag_id = SPORT_TAG_IDS.get(league.upper())
+        if not tag_id:
+            print(f"      Unknown Polymarket league: {league}")
+            return []
+        return self.get_events(tag_id=tag_id, active=True, closed=False, limit=limit)
 
-    # -- CLOB price data (no wallet needed) --
+    def get_sports_game_markets(self, league: str, limit: int = 100) -> list[dict]:
+        """Fetch per-game markets (flattened from events) for a league.
+
+        Filters to events with ``teams`` and ``gameId`` fields (per-game
+        events vs futures/props). Flattens the nested markets and attaches
+        event-level metadata to each market dict.
+        """
+        events = self.get_sports_events(league, limit=limit)
+        markets = []
+        for event in events:
+            # Per-game events have teams and a gameId
+            if not event.get("teams") or not event.get("gameId"):
+                continue
+            event_meta = {
+                "event_title": event.get("title", ""),
+                "event_slug": event.get("slug", ""),
+                "event_start_time": event.get("startTime"),
+                "event_end_date": event.get("endDate"),
+                "event_game_id": event.get("gameId"),
+                "event_teams": event.get("teams", []),
+            }
+            for m in event.get("markets", []):
+                market = {**m, **event_meta}
+                # Parse JSON-encoded fields
+                for field in ("clobTokenIds", "outcomePrices", "outcomes"):
+                    val = market.get(field)
+                    if isinstance(val, str):
+                        try:
+                            market[field] = json.loads(val)
+                        except (json.JSONDecodeError, TypeError):
+                            pass
+                markets.append(market)
+        return markets
+
+    # -- CLOB price data --
 
     def get_midpoint(self, token_id: str) -> Optional[float]:
         """Get midpoint price for a token (0-1 scale)."""
-        result = self._run_cli(["clob", "midpoint", token_id])
+        result = self._get(f"{CLOB_BASE}/midpoint", {"token_id": token_id})
         if isinstance(result, dict):
             mid = result.get("mid") or result.get("midpoint")
             if mid is not None:
                 return float(mid)
         return None
 
-    def get_price(self, token_id: str, side: str = "buy") -> Optional[float]:
+    def get_price(self, token_id: str, side: str = "BUY") -> Optional[float]:
         """Get buy or sell price for a token (0-1 scale)."""
-        result = self._run_cli(["clob", "price", token_id, "--side", side])
+        result = self._get(f"{CLOB_BASE}/price", {"token_id": token_id, "side": side})
         if isinstance(result, dict):
             price = result.get("price")
             if price is not None:
                 return float(price)
         return None
 
-    def get_spread(self, token_id: str) -> Optional[dict]:
-        """Get bid-ask spread for a token."""
-        result = self._run_cli(["clob", "spread", token_id])
-        return result if isinstance(result, dict) else None
-
     def get_book(self, token_id: str) -> dict:
         """Get full order book for a token."""
-        result = self._run_cli(["clob", "book", token_id])
+        result = self._get(f"{CLOB_BASE}/book", {"token_id": token_id})
         return result if isinstance(result, dict) else {}
-
-    def get_fee_rate(self, token_id: str) -> Optional[float]:
-        """Get fee rate for a token."""
-        result = self._run_cli(["clob", "fee-rate", token_id])
-        if isinstance(result, dict):
-            rate = result.get("fee_rate") or result.get("feeRate")
-            if rate is not None:
-                return float(rate)
-        return None
 
     # -- Market price helpers --
 
@@ -166,7 +173,7 @@ class PolymarketClient:
             yes_price = round(mid * 100.0, 2)
             no_price = round(100.0 - yes_price, 2)
         else:
-            buy = self.get_price(token_id, "buy")
+            buy = self.get_price(token_id, "BUY")
             if buy is not None:
                 yes_price = round(buy * 100.0, 2)
                 no_price = round(100.0 - yes_price, 2)
@@ -181,35 +188,17 @@ class PolymarketClient:
             "title": title,
         }
 
-    # -- Position/portfolio data (wallet address, public) --
-
-    def get_positions(self, wallet_address: str) -> list[dict]:
-        """Get open positions for a wallet address."""
-        result = self._run_cli(["data", "positions", wallet_address])
-        return result if isinstance(result, list) else []
-
-    def get_closed_positions(self, wallet_address: str) -> list[dict]:
-        """Get closed/settled positions for a wallet address."""
-        result = self._run_cli(["data", "closed-positions", wallet_address])
-        return result if isinstance(result, list) else []
-
-    def get_trades(self, wallet_address: str, limit: int = 50) -> list[dict]:
-        """Get recent trades for a wallet address."""
-        result = self._run_cli(
-            ["data", "trades", wallet_address, "--limit", str(limit)]
-        )
-        return result if isinstance(result, list) else []
-
-    # -- Connectivity check --
+    # -- Connectivity checks --
 
     def check_geoblock(self) -> dict:
         """Check if the current connection is geoblocked."""
-        result = self._run_cli(["clob", "geoblock"])
+        result = self._get("https://polymarket.com/api/geoblock")
         return result if isinstance(result, dict) else {}
 
     def is_ok(self) -> bool:
         """Check if the CLOB API is reachable."""
-        result = self._run_cli(["clob", "ok"])
-        if isinstance(result, dict):
-            return result.get("ok", False) or result.get("status") == "ok"
-        return False
+        try:
+            r = self.session.get(f"{CLOB_BASE}/", timeout=self.timeout)
+            return r.status_code == 200
+        except requests.RequestException:
+            return False

--- a/polymarket/client.py
+++ b/polymarket/client.py
@@ -188,6 +188,24 @@ class PolymarketClient:
             "title": title,
         }
 
+    # -- Position/portfolio data (public, by wallet address) --
+
+    def get_positions(self, wallet_address: str) -> list[dict]:
+        """Get open positions for a wallet address."""
+        result = self._get(
+            f"{GAMMA_BASE}/data/positions",
+            {"address": wallet_address},
+        )
+        return result if isinstance(result, list) else []
+
+    def get_closed_positions(self, wallet_address: str) -> list[dict]:
+        """Get closed/settled positions for a wallet address."""
+        result = self._get(
+            f"{GAMMA_BASE}/data/closed-positions",
+            {"address": wallet_address},
+        )
+        return result if isinstance(result, list) else []
+
     # -- Connectivity checks --
 
     def check_geoblock(self) -> dict:

--- a/polymarket/discovery.py
+++ b/polymarket/discovery.py
@@ -1,4 +1,4 @@
-"""Schema discovery utility for the Polymarket sports CLI.
+"""Schema discovery utility for the Polymarket Gamma API.
 
 Run once to inspect the raw JSON output and confirm field names
 before tuning the market mapper.
@@ -18,7 +18,7 @@ def discover_schema():
 
     if not client.proxy_url:
         print("POLYMARKET_PROXY not set. Set it to your SOCKS5 proxy URL.")
-        print("Example: export POLYMARKET_PROXY=socks5://127.0.0.1:8080")
+        print("Example: export POLYMARKET_PROXY=socks5h://127.0.0.1:8080")
         sys.exit(1)
 
     print("=== Geoblock check ===")
@@ -29,41 +29,35 @@ def discover_schema():
     print(f"OK: {client.is_ok()}")
     print()
 
-    print("=== Sports market types ===")
-    types = client.get_sports_market_types()
-    print(json.dumps(types[:5], indent=2))
+    print("=== Sports metadata ===")
+    sports = client.get_sports()
+    for s in sports[:10]:
+        print(f"  id={s.get('id')} sport={s.get('sport')} series={s.get('series')}")
+    print(f"  ... ({len(sports)} total)")
     print()
 
-    print("=== NCAAB markets (first 3) ===")
-    ncaab = client.get_sports_markets("NCAAB", limit=3)
-    print(json.dumps(ncaab[:3], indent=2))
+    print("=== MLB game markets (first 3) ===")
+    mlb = client.get_sports_game_markets("MLB", limit=10)
+    for m in mlb[:3]:
+        print(json.dumps({k: v for k, v in m.items() if k != "description"}, indent=2, default=str)[:500])
+        print()
+    print(f"  ... ({len(mlb)} total)")
     print()
 
-    print("=== MLB markets (first 3) ===")
-    mlb = client.get_sports_markets("MLB", limit=3)
-    print(json.dumps(mlb[:3], indent=2))
+    print("=== NCAAB game markets (first 3) ===")
+    ncaab = client.get_sports_game_markets("NCAAB", limit=10)
+    for m in ncaab[:3]:
+        print(json.dumps({k: v for k, v in m.items() if k != "description"}, indent=2, default=str)[:500])
+        print()
+    print(f"  ... ({len(ncaab)} total)")
     print()
 
-    print("=== NCAA basketball search (first 3) ===")
-    search = client.search_markets("NCAA basketball", limit=3)
-    print(json.dumps(search[:3], indent=2))
-    print()
-
-    print("=== MLB search (first 3) ===")
-    search_mlb = client.search_markets("MLB", limit=3)
-    print(json.dumps(search_mlb[:3], indent=2))
-    print()
-
-    print("=== NCAAB teams (first 5) ===")
-    teams = client.get_sports_teams("NCAAB", limit=5)
-    print(json.dumps(teams[:5], indent=2))
-    print()
-
-    # Print discovered field names from the first NCAAB market
-    if ncaab:
-        print("=== Detected NCAAB market fields ===")
-        for key in sorted(ncaab[0].keys()):
-            val = ncaab[0][key]
+    # Print discovered field names from the first market
+    sample = mlb[0] if mlb else (ncaab[0] if ncaab else None)
+    if sample:
+        print("=== Detected market fields ===")
+        for key in sorted(sample.keys()):
+            val = sample[key]
             val_preview = str(val)[:80]
             print(f"  {key}: {type(val).__name__} = {val_preview}")
 

--- a/polymarket/discovery.py
+++ b/polymarket/discovery.py
@@ -1,0 +1,72 @@
+"""Schema discovery utility for the Polymarket sports CLI.
+
+Run once to inspect the raw JSON output and confirm field names
+before tuning the market mapper.
+
+Usage:
+    python -m polymarket.discovery
+"""
+
+import json
+import sys
+
+from .client import PolymarketClient
+
+
+def discover_schema():
+    client = PolymarketClient()
+
+    if not client.proxy_url:
+        print("POLYMARKET_PROXY not set. Set it to your SOCKS5 proxy URL.")
+        print("Example: export POLYMARKET_PROXY=socks5://127.0.0.1:8080")
+        sys.exit(1)
+
+    print("=== Geoblock check ===")
+    print(json.dumps(client.check_geoblock(), indent=2))
+    print()
+
+    print("=== CLOB API health ===")
+    print(f"OK: {client.is_ok()}")
+    print()
+
+    print("=== Sports market types ===")
+    types = client.get_sports_market_types()
+    print(json.dumps(types[:5], indent=2))
+    print()
+
+    print("=== NCAAB markets (first 3) ===")
+    ncaab = client.get_sports_markets("NCAAB", limit=3)
+    print(json.dumps(ncaab[:3], indent=2))
+    print()
+
+    print("=== MLB markets (first 3) ===")
+    mlb = client.get_sports_markets("MLB", limit=3)
+    print(json.dumps(mlb[:3], indent=2))
+    print()
+
+    print("=== NCAA basketball search (first 3) ===")
+    search = client.search_markets("NCAA basketball", limit=3)
+    print(json.dumps(search[:3], indent=2))
+    print()
+
+    print("=== MLB search (first 3) ===")
+    search_mlb = client.search_markets("MLB", limit=3)
+    print(json.dumps(search_mlb[:3], indent=2))
+    print()
+
+    print("=== NCAAB teams (first 5) ===")
+    teams = client.get_sports_teams("NCAAB", limit=5)
+    print(json.dumps(teams[:5], indent=2))
+    print()
+
+    # Print discovered field names from the first NCAAB market
+    if ncaab:
+        print("=== Detected NCAAB market fields ===")
+        for key in sorted(ncaab[0].keys()):
+            val = ncaab[0][key]
+            val_preview = str(val)[:80]
+            print(f"  {key}: {type(val).__name__} = {val_preview}")
+
+
+if __name__ == "__main__":
+    discover_schema()

--- a/polymarket/market_mapper.py
+++ b/polymarket/market_mapper.py
@@ -359,13 +359,16 @@ class PolymarketMarketMapper:
     def get_market_prices(self, market: dict) -> dict:
         """Extract prices from a market dict (cached data, no API call).
 
-        Returns dict with yes_price, no_price (0-100 scale), token_id, title.
+        Returns dict with yes_price, no_price (0-100 scale), yes_token_id,
+        no_token_id, token_id (alias for yes), and title.
         """
         yes_price, no_price = self._get_prices(market)
         return {
             "yes_price": yes_price,
             "no_price": no_price,
-            "token_id": self._get_token_id(market),
+            "token_id": self._get_yes_token(market),
+            "yes_token_id": self._get_yes_token(market),
+            "no_token_id": self._get_no_token(market),
             "title": self._get_title(market),
         }
 

--- a/polymarket/market_mapper.py
+++ b/polymarket/market_mapper.py
@@ -1,6 +1,6 @@
 """Map ESPN games to Polymarket sports market tokens.
 
-Polymarket sports markets are fetched via the CLI's ``sports list`` command.
+Polymarket sports markets are fetched via the Gamma API (see ``client.py``).
 Because the exact JSON schema may evolve, field names are auto-detected from
 the first market dict with fallbacks for common variants.
 """

--- a/polymarket/market_mapper.py
+++ b/polymarket/market_mapper.py
@@ -98,8 +98,9 @@ class PolymarketMarketMapper:
             from datetime import timezone
             return datetime.fromtimestamp(raw, tz=timezone.utc)
         raw = str(raw)
-        # Try ISO with explicit timezone first
-        if raw.endswith("Z") or "+" in raw[10:]:
+        # Try ISO with explicit timezone first (Z, +HH:MM, or -HH:MM offset)
+        has_tz = raw.endswith("Z") or "+" in raw[10:] or re.search(r"-\d{2}:\d{2}$", raw)
+        if has_tz:
             try:
                 return datetime.fromisoformat(raw.replace("Z", "+00:00"))
             except (ValueError, TypeError):

--- a/polymarket/market_mapper.py
+++ b/polymarket/market_mapper.py
@@ -1,0 +1,417 @@
+"""Map ESPN games to Polymarket sports market tokens.
+
+Polymarket sports markets are fetched via the CLI's ``sports list`` command.
+Because the exact JSON schema may evolve, field names are auto-detected from
+the first market dict with fallbacks for common variants.
+"""
+
+import re
+from datetime import datetime, timedelta
+from typing import Optional
+
+from kalshi.market_mapper import normalize_team_name, extract_school_keyword
+
+
+def _first_present(d: dict, keys: list[str]):
+    """Return the value for the first key found in *d*, or ``None``."""
+    for k in keys:
+        if k in d and d[k] is not None:
+            return d[k]
+    return None
+
+
+class PolymarketMarketMapper:
+    """Map games to Polymarket sports market tokens."""
+
+    # Candidate field names the CLI might use for each concept.
+    _TITLE_CANDIDATES = ["question", "title", "name", "groupItemTitle", "market_title"]
+    _DATE_CANDIDATES = ["game_start_time", "start_time", "game_date", "startDate",
+                        "endDate", "end_date_iso", "game_start"]
+    _TOKEN_CANDIDATES = ["clobTokenIds", "token_id", "condition_id", "conditionId",
+                         "id", "market_id"]
+    _OUTCOME_PRICE_CANDIDATES = ["outcomePrices", "outcome_prices"]
+    _OUTCOMES_CANDIDATES = ["outcomes", "groupItemTitle"]
+    _MARKET_TYPE_CANDIDATES = ["market_type", "marketType", "bet_type", "type"]
+    _SPREAD_CANDIDATES = ["spread_value", "spreadValue", "line", "handicap",
+                          "floor_strike", "point_spread"]
+
+    def __init__(self, markets: list[dict]):
+        self.markets = markets
+        self._detect_fields()
+        self._build_index()
+
+    def _detect_fields(self):
+        """Auto-detect which JSON field names are present."""
+        sample = self.markets[0] if self.markets else {}
+        all_keys = set(sample.keys())
+
+        # If markets contain nested 'markets' arrays (event-level wrapping),
+        # flatten one level.
+        if "markets" in sample and isinstance(sample["markets"], list):
+            flat = []
+            for event in self.markets:
+                for m in event.get("markets", []):
+                    m["_event"] = {
+                        k: v for k, v in event.items() if k != "markets"
+                    }
+                    flat.append(m)
+            self.markets = flat
+            sample = flat[0] if flat else {}
+            all_keys = set(sample.keys())
+
+        def _pick(candidates):
+            for c in candidates:
+                if c in all_keys:
+                    return c
+            return candidates[0]  # fallback to first candidate
+
+        self._f_title = _pick(self._TITLE_CANDIDATES)
+        self._f_date = _pick(self._DATE_CANDIDATES)
+        self._f_token = _pick(self._TOKEN_CANDIDATES)
+        self._f_prices = _pick(self._OUTCOME_PRICE_CANDIDATES)
+        self._f_outcomes = _pick(self._OUTCOMES_CANDIDATES)
+        self._f_type = _pick(self._MARKET_TYPE_CANDIDATES)
+        self._f_spread = _pick(self._SPREAD_CANDIDATES)
+
+    def _build_index(self):
+        """Build lookup structures."""
+        self.by_id = {}
+        for m in self.markets:
+            token = self._get_token_id(m)
+            if token:
+                self.by_id[token] = m
+
+    # -- Field accessors --
+
+    def _get_title(self, market: dict) -> str:
+        return str(market.get(self._f_title, "") or "")
+
+    def _get_date(self, market: dict) -> Optional[datetime]:
+        raw = market.get(self._f_date)
+        if raw is None:
+            # Try event-level date
+            event = market.get("_event", {})
+            raw = _first_present(event, self._DATE_CANDIDATES)
+        if raw is None:
+            return None
+        if isinstance(raw, (int, float)):
+            from datetime import timezone
+            return datetime.fromtimestamp(raw, tz=timezone.utc)
+        raw = str(raw)
+        # Try ISO with explicit timezone first
+        if raw.endswith("Z") or "+" in raw[10:]:
+            try:
+                return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+            except (ValueError, TypeError):
+                pass
+        for fmt in (
+            "%Y-%m-%dT%H:%M:%S.%f",
+            "%Y-%m-%dT%H:%M:%S",
+            "%Y-%m-%d %H:%M:%S",
+            "%Y-%m-%d",
+        ):
+            try:
+                return datetime.strptime(raw, fmt)
+            except ValueError:
+                continue
+        return None
+
+    def _get_token_id(self, market: dict) -> Optional[str]:
+        val = market.get(self._f_token)
+        if isinstance(val, list):
+            return val[0] if val else None
+        return str(val) if val else None
+
+    def _get_yes_token(self, market: dict) -> Optional[str]:
+        val = market.get(self._f_token)
+        if isinstance(val, list):
+            return val[0] if val else None
+        return str(val) if val else None
+
+    def _get_no_token(self, market: dict) -> Optional[str]:
+        val = market.get(self._f_token)
+        if isinstance(val, list) and len(val) > 1:
+            return val[1]
+        return None
+
+    def _get_market_type(self, market: dict) -> str:
+        raw = market.get(self._f_type)
+        if raw:
+            raw = str(raw).lower()
+            if "spread" in raw:
+                return "spread"
+            if "total" in raw or "over" in raw:
+                return "total"
+            if "money" in raw or "game" in raw or "winner" in raw or "moneyline" in raw:
+                return "game"
+            return raw
+        # Infer from title
+        title = self._get_title(market).lower()
+        if "spread" in title or "wins by" in title:
+            return "spread"
+        if "total" in title or "over" in title or "under" in title:
+            return "total"
+        return "game"
+
+    def _get_spread_value(self, market: dict) -> Optional[float]:
+        val = market.get(self._f_spread)
+        if val is not None:
+            try:
+                return float(val)
+            except (TypeError, ValueError):
+                pass
+        # Try parsing from title (e.g. "Duke -5.5")
+        title = self._get_title(market)
+        match = re.search(r"[+-]?\d+\.?\d*", title)
+        if match:
+            try:
+                return float(match.group())
+            except ValueError:
+                pass
+        return None
+
+    def _get_prices(self, market: dict) -> tuple[Optional[float], Optional[float]]:
+        """Extract (yes_price, no_price) in 0-100 cent scale."""
+        raw = market.get(self._f_prices)
+        if isinstance(raw, list) and len(raw) >= 2:
+            try:
+                yes = float(raw[0]) * 100.0
+                no = float(raw[1]) * 100.0
+                return round(yes, 2), round(no, 2)
+            except (TypeError, ValueError):
+                pass
+        return None, None
+
+    # -- Team matching --
+
+    def _extract_teams_from_title(self, market: dict) -> tuple[str, str]:
+        """Try to parse two team names from the market title.
+
+        Common patterns:
+          "Will <Team A> beat <Team B>?"
+          "<Team A> vs <Team B>"
+          "<Team A> vs. <Team B>"
+          "<Team A> @ <Team B>"
+        """
+        title = self._get_title(market)
+        patterns = [
+            r"(?:will\s+)?(.+?)\s+(?:beat|defeat)\s+(.+?)[\s?]*$",
+            r"(.+?)\s+(?:vs\.?|@)\s+(.+?)(?:\s*[-\(]|$)",
+            r"(.+?)\s+(?:vs\.?|@)\s+(.+)",
+        ]
+        for pattern in patterns:
+            match = re.search(pattern, title, re.IGNORECASE)
+            if match:
+                return match.group(1).strip(), match.group(2).strip()
+        return "", ""
+
+    def _teams_match(self, market: dict, home_keyword: str, away_keyword: str) -> bool:
+        """Check if both team keywords appear in the market title."""
+        title = self._get_title(market).lower()
+        # Also check event-level title if available
+        event_title = str(market.get("_event", {}).get("title", "")).lower()
+        combined = f"{title} {event_title}"
+
+        home_found = home_keyword in combined
+        away_found = away_keyword in combined
+
+        if home_found and away_found:
+            return True
+
+        # Try abbreviation variants
+        variants = [
+            (r"\bstate\b", "st."), (r"\bst\.", "state"),
+            (r"\bsaint\b", "st."), (r"\bst\.", "saint"),
+        ]
+        for pattern, replacement in variants:
+            home_alt = re.sub(pattern, replacement, home_keyword)
+            away_alt = re.sub(pattern, replacement, away_keyword)
+            if not home_found and home_alt != home_keyword and home_alt in combined:
+                home_found = True
+            if not away_found and away_alt != away_keyword and away_alt in combined:
+                away_found = True
+
+        return home_found and away_found
+
+    # -- Public matching API --
+
+    def _time_distance(self, market: dict, game_time: str) -> int:
+        """Minutes between the market's start time and the provided game_time.
+
+        Both ``game_time`` and the market datetime are normalised to UTC
+        before comparison. ``game_time`` is expected as ``"HH:MM"`` in UTC
+        (the format used by ESPN and passed through by predict.py).
+
+        Returns a large value if the market has no parseable time.
+        """
+        if not game_time:
+            return 0
+        market_dt = self._get_date(market)
+        if market_dt is None:
+            return 9999
+        try:
+            parts = game_time.replace(":", "")[:4]
+            gt_minutes = int(parts[:2]) * 60 + int(parts[2:4])
+
+            # Normalize market time to UTC if it's timezone-aware
+            if hasattr(market_dt, "utcoffset") and market_dt.utcoffset() is not None:
+                from datetime import timezone
+                market_utc = market_dt.astimezone(timezone.utc)
+                mt_minutes = market_utc.hour * 60 + market_utc.minute
+            else:
+                # Assume naive datetimes are already UTC (Polymarket convention)
+                mt_minutes = market_dt.hour * 60 + market_dt.minute
+
+            return abs(gt_minutes - mt_minutes)
+        except (ValueError, IndexError):
+            return 9999
+
+    def _pick_closest(self, candidates: list[dict], game_time: str) -> Optional[dict]:
+        """From multiple candidate markets, pick the one closest to game_time.
+
+        If game_time is empty or all candidates lack time info, returns the
+        first candidate (same behavior as before).
+        """
+        if not candidates:
+            return None
+        if len(candidates) == 1 or not game_time:
+            return candidates[0]
+        return min(candidates, key=lambda m: self._time_distance(m, game_time))
+
+    def find_all_markets_for_game(
+        self,
+        home_team: str,
+        away_team: str,
+        game_date: datetime,
+        game_time: str = "",
+    ) -> list[dict]:
+        """Find all Polymarket markets for a given game.
+
+        Args:
+            game_time: Optional "HH:MM" (UTC) to disambiguate doubleheaders.
+                       When provided, results are sorted by time proximity.
+        """
+        home_keyword = extract_school_keyword(home_team)
+        away_keyword = extract_school_keyword(away_team)
+
+        matches = []
+        for market in self.markets:
+            market_date = self._get_date(market)
+            if market_date:
+                date_diff = abs((market_date.date() - game_date.date()).days)
+                if date_diff > 1:
+                    continue
+
+            if self._teams_match(market, home_keyword, away_keyword):
+                matches.append(market)
+
+        if game_time and len(matches) > 1:
+            matches.sort(key=lambda m: self._time_distance(m, game_time))
+
+        return matches
+
+    def find_game_market(
+        self,
+        home_team: str,
+        away_team: str,
+        game_date: datetime,
+        game_time: str = "",
+    ) -> Optional[dict]:
+        """Find the moneyline/game-winner market for a matchup."""
+        candidates = self.find_all_markets_for_game(
+            home_team, away_team, game_date, game_time=game_time,
+        )
+        game_markets = [m for m in candidates if self._get_market_type(m) == "game"]
+        return self._pick_closest(game_markets, game_time)
+
+    def find_spread_market(
+        self,
+        home_team: str,
+        away_team: str,
+        game_date: datetime,
+        spread: float,
+        game_time: str = "",
+    ) -> Optional[dict]:
+        """Find the best-matching spread market for a game."""
+        candidates = self.find_all_markets_for_game(
+            home_team, away_team, game_date, game_time=game_time,
+        )
+        spread_markets = [m for m in candidates if self._get_market_type(m) == "spread"]
+
+        if not spread_markets:
+            return None
+
+        best = None
+        best_diff = float("inf")
+        for m in spread_markets:
+            market_spread = self._get_spread_value(m)
+            if market_spread is not None:
+                diff = abs(market_spread - abs(spread))
+                if diff < best_diff:
+                    best_diff = diff
+                    best = m
+            elif best is None:
+                best = m
+
+        return best
+
+    def get_market_prices(self, market: dict) -> dict:
+        """Extract prices from a market dict (cached data, no API call).
+
+        Returns dict with yes_price, no_price (0-100 scale), token_id, title.
+        """
+        yes_price, no_price = self._get_prices(market)
+        return {
+            "yes_price": yes_price,
+            "no_price": no_price,
+            "token_id": self._get_token_id(market),
+            "title": self._get_title(market),
+        }
+
+    def infer_yes_team(
+        self,
+        market: dict,
+        home_team: str,
+        away_team: str,
+    ) -> Optional[str]:
+        """Infer which team is YES for a game-winner market.
+
+        Common patterns:
+          "Will <Team> beat <Other>?" -> Team = YES
+          "<TeamA> vs <TeamB>" -> first team = YES (convention)
+        """
+        title = self._get_title(market).lower()
+        home_keyword = extract_school_keyword(home_team).lower()
+        away_keyword = extract_school_keyword(away_team).lower()
+
+        # "Will X beat Y?" or "X wins" -> X is YES
+        beat_match = re.search(
+            r"(?:will\s+)?(.+?)\s+(?:beat|defeat|win)", title, re.IGNORECASE
+        )
+        if beat_match:
+            candidate = beat_match.group(1).strip().lower()
+            if home_keyword in candidate:
+                return home_team
+            if away_keyword in candidate:
+                return away_team
+
+        # Outcomes list might tell us
+        outcomes = market.get(self._f_outcomes, [])
+        if isinstance(outcomes, list) and len(outcomes) >= 2:
+            o0 = str(outcomes[0]).lower()
+            o1 = str(outcomes[1]).lower()
+            if home_keyword in o0:
+                return home_team
+            if away_keyword in o0:
+                return away_team
+
+        # Fallback: first team in title is YES
+        team_a, team_b = self._extract_teams_from_title(market)
+        if team_a:
+            a_kw = extract_school_keyword(team_a).lower()
+            if a_kw == home_keyword or home_keyword in a_kw:
+                return home_team
+            if a_kw == away_keyword or away_keyword in a_kw:
+                return away_team
+
+        return None

--- a/predict.py
+++ b/predict.py
@@ -822,6 +822,7 @@ def get_polymarket_spread_edge(
         prices = mapper.get_market_prices(market)
         token_id = prices.get("token_id")
         title = prices.get("title", "")
+        event_slug = market.get("event_slug", "")
 
         # Try live prices if we have a token
         if token_id:
@@ -858,7 +859,7 @@ def get_polymarket_spread_edge(
             "Poly_Edge_Pct": f"{edge * 100:+.1f}%",
             "Poly_Rating": rating.value,
             "Poly_Units": units,
-            "Poly_Ticker": token_id,
+            "Poly_Ticker": event_slug or token_id,
             "Poly_Side": poly_side,
             "Poly_Title": title,
         }
@@ -906,6 +907,7 @@ def get_polymarket_game_edge(
         prices = mapper.get_market_prices(market)
         token_id = prices.get("token_id")
         title = prices.get("title", "")
+        event_slug = market.get("event_slug", "")
 
         # Try live prices
         if token_id:
@@ -965,7 +967,7 @@ def get_polymarket_game_edge(
             "Poly_Edge_Pct": f"{best['edge'] * 100:+.1f}%",
             "Poly_Rating": rating,
             "Poly_Units": min(units, 0.5),
-            "Poly_Ticker": token_id,
+            "Poly_Ticker": event_slug or token_id,
             "Poly_Side": best["side"],
             "Poly_Title": title,
             "Poly_Yes_Team": yes_team,

--- a/predict.py
+++ b/predict.py
@@ -821,12 +821,13 @@ def get_polymarket_spread_edge(
 
         prices = mapper.get_market_prices(market)
         token_id = prices.get("token_id")
+        no_token_id = prices.get("no_token_id")
         title = prices.get("title", "")
         event_slug = market.get("event_slug", "")
 
-        # Try live prices if we have a token
+        # Try live prices -- fetch YES and NO tokens independently
         if token_id:
-            live = client.get_market_prices(token_id, title=title)
+            live = client.get_market_prices(token_id, title=title, no_token_id=no_token_id)
             if live.get("yes_price") is not None:
                 prices = live
 
@@ -906,12 +907,13 @@ def get_polymarket_game_edge(
 
         prices = mapper.get_market_prices(market)
         token_id = prices.get("token_id")
+        no_token_id = prices.get("no_token_id")
         title = prices.get("title", "")
         event_slug = market.get("event_slug", "")
 
-        # Try live prices
+        # Try live prices -- fetch YES and NO tokens independently
         if token_id:
-            live = client.get_market_prices(token_id, title=title)
+            live = client.get_market_prices(token_id, title=title, no_token_id=no_token_id)
             if live.get("yes_price") is not None:
                 prices = live
 

--- a/predict.py
+++ b/predict.py
@@ -21,7 +21,7 @@ except ImportError:
 
 from kalshi import KalshiClient, MarketMapper
 from betting import calculate_edge, get_rating, recommended_units, EdgeRating, STANDARD_IMPLIED_PROB, VALUE_RATINGS, RATING_RANK, kalshi_implied_prob, american_odds_to_implied_prob
-from betting.ev_calculator import kalshi_fee_cents
+from betting.ev_calculator import kalshi_fee_cents, polymarket_implied_prob, polymarket_fee_cents
 from betting import calculate_line_shopping
 from betting.line_shopping import LineShoppingResult
 from hasla import HASLA_GAME_FEATURE_COLUMNS, load_snapshot_file as load_hasla_snapshot_file, load_team_map as load_hasla_team_map, matchup_features_for_game as hasla_matchup_features_for_game
@@ -747,6 +747,236 @@ def get_kalshi_game_edge(
         return result
 
 
+# ---------------------------------------------------------------------------
+# Polymarket integration
+# ---------------------------------------------------------------------------
+
+def fetch_polymarket_markets(league=None):
+    """Fetch Polymarket sports markets and build mapper.
+
+    Returns (client, mapper) or (None, None) if unconfigured/unavailable.
+    """
+    target_league = ACTIVE_LEAGUE if league is None else normalize_league(league)
+    proxy = os.getenv("POLYMARKET_PROXY")
+    if not proxy:
+        print("      POLYMARKET_PROXY not set. Skipping Polymarket integration.")
+        return None, None
+
+    poly_league_map = {
+        "mens": "NCAAB",
+        "womens": "NCAAB",
+        "mlb": "MLB",
+    }
+    poly_league = poly_league_map.get(target_league, "NCAAB")
+    print(f"   -> Fetching Polymarket markets ({poly_league})...")
+
+    try:
+        from polymarket import PolymarketClient, PolymarketMarketMapper
+
+        client = PolymarketClient(proxy_url=proxy)
+        markets = client.get_sports_markets(poly_league)
+        if markets:
+            print(f"      Found {len(markets)} Polymarket {poly_league} markets")
+            mapper = PolymarketMarketMapper(markets)
+            return client, mapper
+        else:
+            print(f"      No Polymarket {poly_league} markets found")
+            return client, None
+    except (FileNotFoundError, OSError, ValueError) as e:
+        print(f"      Polymarket error: {e}")
+        return None, None
+
+
+def get_polymarket_spread_edge(
+    client, mapper, home_team, away_team, game_date,
+    spread, model_prob, picked_team, picked_spread,
+):
+    """Get Polymarket spread market data and calculate edge.
+
+    Returns dict with Poly_* keys, parallel to get_kalshi_edge().
+    """
+    from kalshi.market_mapper import extract_school_keyword
+
+    result = {
+        "Poly_Yes": None,
+        "Poly_No": None,
+        "Poly_Price": None,
+        "Poly_Fee": None,
+        "Poly_Edge": None,
+        "Poly_Edge_Pct": None,
+        "Poly_Rating": None,
+        "Poly_Units": None,
+        "Poly_Ticker": None,
+        "Poly_Side": None,
+        "Poly_Title": None,
+    }
+
+    if not client or not mapper:
+        return result
+
+    try:
+        market = mapper.find_spread_market(home_team, away_team, game_date, spread)
+        if not market:
+            return result
+
+        prices = mapper.get_market_prices(market)
+        token_id = prices.get("token_id")
+        title = prices.get("title", "")
+
+        # Try live prices if we have a token
+        if token_id:
+            live = client.get_market_prices(token_id, title=title)
+            if live.get("yes_price") is not None:
+                prices = live
+
+        yes_price = prices.get("yes_price")
+        no_price = prices.get("no_price")
+
+        # Determine side: same logic as Kalshi spread edge
+        is_underdog = picked_spread > 0
+        if is_underdog:
+            poly_side = "NO"
+            bet_price = no_price
+        else:
+            poly_side = "YES"
+            bet_price = yes_price
+
+        if bet_price is None:
+            return result
+
+        implied_prob = polymarket_implied_prob(bet_price)
+        edge = calculate_edge(model_prob, implied_prob)
+        rating = get_rating(edge)
+        units = recommended_units(edge, implied_prob)
+
+        result = {
+            "Poly_Yes": yes_price,
+            "Poly_No": no_price,
+            "Poly_Price": bet_price,
+            "Poly_Fee": round(polymarket_fee_cents(bet_price), 1),
+            "Poly_Edge": edge,
+            "Poly_Edge_Pct": f"{edge * 100:+.1f}%",
+            "Poly_Rating": rating.value,
+            "Poly_Units": units,
+            "Poly_Ticker": token_id,
+            "Poly_Side": poly_side,
+            "Poly_Title": title,
+        }
+    except Exception as e:
+        print(f"      Polymarket spread error for {away_team} @ {home_team}: {type(e).__name__}: {e}")
+
+    return result
+
+
+def get_polymarket_game_edge(
+    client, mapper, home_team, away_team, game_date, model_home_win_prob,
+):
+    """Get best Polymarket GAME market side and edge based on P(home wins).
+
+    Returns dict with Poly_* keys, parallel to get_kalshi_game_edge().
+    """
+    result = {
+        "Poly_Yes": None,
+        "Poly_No": None,
+        "Poly_Price": None,
+        "Poly_Fee": None,
+        "Poly_Edge": None,
+        "Poly_Edge_Pct": None,
+        "Poly_Rating": None,
+        "Poly_Units": None,
+        "Poly_Ticker": None,
+        "Poly_Side": None,
+        "Poly_Title": None,
+        "Poly_Yes_Team": None,
+        "Poly_Picked_Team": None,
+    }
+
+    if not client or not mapper:
+        return result
+
+    try:
+        market = mapper.find_game_market(home_team, away_team, game_date)
+        if not market:
+            return result
+
+        yes_team = mapper.infer_yes_team(market, home_team, away_team)
+        if not yes_team:
+            return result
+
+        prices = mapper.get_market_prices(market)
+        token_id = prices.get("token_id")
+        title = prices.get("title", "")
+
+        # Try live prices
+        if token_id:
+            live = client.get_market_prices(token_id, title=title)
+            if live.get("yes_price") is not None:
+                prices = live
+
+        yes_price = prices.get("yes_price")
+        no_price = prices.get("no_price")
+        if yes_price is None and no_price is None:
+            return result
+
+        yes_prob = model_home_win_prob if yes_team == home_team else (1.0 - model_home_win_prob)
+        side_candidates = []
+
+        if yes_price is not None:
+            implied_yes = polymarket_implied_prob(yes_price)
+            edge_yes = calculate_edge(yes_prob, implied_yes)
+            side_candidates.append({
+                "side": "YES", "price": yes_price,
+                "prob": yes_prob, "edge": edge_yes,
+                "picked_team": yes_team,
+            })
+
+        if no_price is not None:
+            no_prob = 1.0 - yes_prob
+            implied_no = polymarket_implied_prob(no_price)
+            edge_no = calculate_edge(no_prob, implied_no)
+            picked_team = away_team if yes_team == home_team else home_team
+            side_candidates.append({
+                "side": "NO", "price": no_price,
+                "prob": no_prob, "edge": edge_no,
+                "picked_team": picked_team,
+            })
+
+        if not side_candidates:
+            return result
+
+        best = max(side_candidates, key=lambda c: c["edge"])
+
+        # Apply same live rating gates as Kalshi GAME markets
+        rating = get_kalshi_game_live_rating(
+            best["edge"], best["prob"], best["price"],
+        )
+        units = (
+            recommended_units(best["edge"], polymarket_implied_prob(best["price"]))
+            if rating in VALUE_RATINGS
+            else 0.0
+        )
+
+        result = {
+            "Poly_Yes": yes_price,
+            "Poly_No": no_price,
+            "Poly_Price": best["price"],
+            "Poly_Fee": round(polymarket_fee_cents(best["price"]), 1),
+            "Poly_Edge": best["edge"],
+            "Poly_Edge_Pct": f"{best['edge'] * 100:+.1f}%",
+            "Poly_Rating": rating,
+            "Poly_Units": min(units, 0.5),
+            "Poly_Ticker": token_id,
+            "Poly_Side": best["side"],
+            "Poly_Title": title,
+            "Poly_Yes_Team": yes_team,
+            "Poly_Picked_Team": best["picked_team"],
+        }
+    except Exception as e:
+        print(f"      Polymarket GAME error for {away_team} @ {home_team}: {type(e).__name__}: {e}")
+
+    return result
+
+
 def calculate_production_features(row, h_stats, a_stats, game_date=None, torvik_context=None):
     """Calculate features needed for prediction."""
     # --- Original Features ---
@@ -962,9 +1192,10 @@ def main(spread_overrides=None, league="mens"):
         print(f"   WARNING: Data is {days_old} days old. Run main.py to update!")
 
     # Fetch network resources in parallel while loading local model/venue data
-    with ThreadPoolExecutor(max_workers=2) as _io_pool:
+    with ThreadPoolExecutor(max_workers=3) as _io_pool:
         _schedule_future = _io_pool.submit(fetch_schedule)
         _kalshi_future = _io_pool.submit(fetch_kalshi_markets, ACTIVE_LEAGUE)
+        _poly_future = _io_pool.submit(fetch_polymarket_markets, ACTIVE_LEAGUE)
 
         win_bundle = None
         try:
@@ -995,6 +1226,12 @@ def main(spread_overrides=None, league="mens"):
         except Exception as e:
             print(f"   WARNING: Kalshi market fetch failed: {e}")
             kalshi_client, kalshi_mapper = None, None
+
+        try:
+            poly_client, poly_mapper = _poly_future.result()
+        except Exception as e:
+            print(f"   WARNING: Polymarket fetch failed: {e}")
+            poly_client, poly_mapper = None, None
 
     spread_predictions = []
     game_predictions = []
@@ -1110,13 +1347,21 @@ def main(spread_overrides=None, league="mens"):
         except (TypeError, AttributeError):
             time_str = g['date'].strftime("%m/%d %I:%M %p")
 
-        # Build GAME market picks (Kalshi-only) from P(win) model.
+        # Build GAME market picks from P(win) model (Kalshi + Polymarket).
         if win_bundle is not None:
             try:
                 home_win_prob, win_variant = predict_home_win_prob(row, win_bundle)
                 game_kalshi = get_kalshi_game_edge(
                     kalshi_client,
                     kalshi_mapper,
+                    g['home_raw'],
+                    g['away_raw'],
+                    g['date'],
+                    home_win_prob,
+                )
+                game_poly = get_polymarket_game_edge(
+                    poly_client,
+                    poly_mapper,
                     g['home_raw'],
                     g['away_raw'],
                     g['date'],
@@ -1157,7 +1402,10 @@ def main(spread_overrides=None, league="mens"):
                         )
                     )
 
-                    if game_kalshi.get("Rating") in VALUE_RATINGS and side_prob >= GAME_GOOD_MIN_PROB:
+                    # Check if either Kalshi or Polymarket has a value rating
+                    kalshi_is_value = game_kalshi.get("Rating") in VALUE_RATINGS
+                    poly_is_value = game_poly.get("Poly_Rating") in VALUE_RATINGS
+                    if (kalshi_is_value or poly_is_value) and side_prob >= GAME_GOOD_MIN_PROB:
                         game_predictions.append({
                             "Bet_Type": "game",
                             "Date/Time": time_str,
@@ -1189,6 +1437,14 @@ def main(spread_overrides=None, league="mens"):
                             "Std_Rating": "PASS",
                             "Std_Units": 0.0,
                             "Breakeven_Spread": np.nan,
+                            # Polymarket game data
+                            "Poly_Side": game_poly.get("Poly_Side"),
+                            "Poly_Price": game_poly.get("Poly_Price"),
+                            "Poly_Fee": game_poly.get("Poly_Fee"),
+                            "Poly_Edge_Pct": game_poly.get("Poly_Edge_Pct"),
+                            "Poly_Rating": game_poly.get("Poly_Rating"),
+                            "Poly_Units": game_poly.get("Poly_Units"),
+                            "Poly_Ticker": game_poly.get("Poly_Ticker"),
                         })
             except (KeyError, TypeError, ValueError) as e:
                 print(f"      WARNING: GAME market prediction failed for {matchup_key}: {e}")
@@ -1260,6 +1516,18 @@ def main(spread_overrides=None, league="mens"):
             picked_spread,
         )
 
+        poly_data = get_polymarket_spread_edge(
+            poly_client,
+            poly_mapper,
+            g['home_raw'],
+            g['away_raw'],
+            g['date'],
+            resolved_spread,
+            conf,
+            picked_team,
+            picked_spread,
+        )
+
         is_home_pick = (prob > 0.5)
         try:
             line_shopping = calculate_line_shopping(
@@ -1308,6 +1576,14 @@ def main(spread_overrides=None, league="mens"):
             "Std_Rating": get_rating(std_edge).value,
             "Std_Units": recommended_units(std_edge, std_implied) if std_edge > 0 else 0.0,
             "Std_Odds": g.get("home_spread_odds", "") if is_home_pick else g.get("away_spread_odds", ""),
+            # Polymarket spread data
+            "Poly_Side": poly_data.get("Poly_Side"),
+            "Poly_Price": poly_data.get("Poly_Price"),
+            "Poly_Fee": poly_data.get("Poly_Fee"),
+            "Poly_Edge_Pct": poly_data.get("Poly_Edge_Pct"),
+            "Poly_Rating": poly_data.get("Poly_Rating"),
+            "Poly_Units": poly_data.get("Poly_Units"),
+            "Poly_Ticker": poly_data.get("Poly_Ticker"),
         }
 
         if g['home_raw'] not in pick_str and g['away_raw'] not in pick_str:
@@ -1377,7 +1653,8 @@ def main(spread_overrides=None, league="mens"):
 
         value_bets = csv_df[
             (csv_df['Std_Rating'].isin(VALUE_RATINGS)) |
-            (csv_df['Rating'].isin(VALUE_RATINGS))
+            (csv_df['Rating'].isin(VALUE_RATINGS)) |
+            (csv_df.get('Poly_Rating', pd.Series(dtype=str)).isin(VALUE_RATINGS))
         ]
         if len(value_bets) > 0:
             print(f"\nVALUE BETS ({len(value_bets)} found):")
@@ -1386,14 +1663,28 @@ def main(spread_overrides=None, league="mens"):
                 if pd.isna(std_rating):
                     std_rating = 'PASS'
                 kalshi_rating = row.get('Rating', None) if pd.notna(row.get('Rating')) else None
+                poly_r = row.get('Poly_Rating', 'PASS')
+                if pd.isna(poly_r):
+                    poly_r = 'PASS'
                 std_rank = RATING_RANK.get(std_rating, 0)
                 kalshi_rank = RATING_RANK.get(kalshi_rating, 0)
-                best_rating = kalshi_rating if kalshi_rank > std_rank else std_rating
+                poly_rank = RATING_RANK.get(poly_r, 0)
+                best_rank = max(std_rank, kalshi_rank, poly_rank)
+                best_rating = (
+                    kalshi_rating if kalshi_rank == best_rank else
+                    poly_r if poly_rank == best_rank else
+                    std_rating
+                )
                 print(f"   [{row.get('Bet_Type', 'spread')}:{best_rating}] {row['Pick']}")
                 if kalshi_rating in VALUE_RATINGS:
                     side = row['Kalshi_Side'] if row['Kalshi_Side'] else "?"
                     fee = row.get('Kalshi_Fee', 0) or 0
                     print(f"      Kalshi: Buy {side} @ {row['Kalshi_Price']}c + {fee:.1f}c fee | Edge: {row['Edge_Pct']} | {row['Units']:.1f}U")
+                poly_rating = row.get('Poly_Rating', 'PASS')
+                if poly_rating in VALUE_RATINGS:
+                    p_side = row.get('Poly_Side', '?')
+                    p_fee = row.get('Poly_Fee', 0) or 0
+                    print(f"      Poly: Buy {p_side} @ {row.get('Poly_Price', '?')}c + {p_fee:.1f}c fee | Edge: {row.get('Poly_Edge_Pct', 'N/A')} | {row.get('Poly_Units', 0):.1f}U")
                 if std_rating in VALUE_RATINGS:
                     print(f"      Std Book: Edge {row['Std_Edge_Pct']} | {row['Std_Units']:.1f}U")
     else:

--- a/predict.py
+++ b/predict.py
@@ -774,7 +774,7 @@ def fetch_polymarket_markets(league=None):
         from polymarket import PolymarketClient, PolymarketMarketMapper
 
         client = PolymarketClient(proxy_url=proxy)
-        markets = client.get_sports_markets(poly_league)
+        markets = client.get_sports_game_markets(poly_league)
         if markets:
             print(f"      Found {len(markets)} Polymarket {poly_league} markets")
             mapper = PolymarketMarketMapper(markets)

--- a/predict.py
+++ b/predict.py
@@ -825,11 +825,14 @@ def get_polymarket_spread_edge(
         title = prices.get("title", "")
         event_slug = market.get("event_slug", "")
 
-        # Try live prices -- fetch YES and NO tokens independently
+        # Try live prices -- merge selectively so cached values survive
+        # when one side's live fetch fails
         if token_id:
             live = client.get_market_prices(token_id, title=title, no_token_id=no_token_id)
             if live.get("yes_price") is not None:
-                prices = live
+                prices["yes_price"] = live["yes_price"]
+            if live.get("no_price") is not None:
+                prices["no_price"] = live["no_price"]
 
         yes_price = prices.get("yes_price")
         no_price = prices.get("no_price")
@@ -911,11 +914,13 @@ def get_polymarket_game_edge(
         title = prices.get("title", "")
         event_slug = market.get("event_slug", "")
 
-        # Try live prices -- fetch YES and NO tokens independently
+        # Try live prices -- merge selectively so cached values survive
         if token_id:
             live = client.get_market_prices(token_id, title=title, no_token_id=no_token_id)
             if live.get("yes_price") is not None:
-                prices = live
+                prices["yes_price"] = live["yes_price"]
+            if live.get("no_price") is not None:
+                prices["no_price"] = live["no_price"]
 
         yes_price = prices.get("yes_price")
         no_price = prices.get("no_price")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,3 +32,8 @@ train = "model:train_and_evaluate"
 train-win = "model_win:train_win_models"
 predict = "predict:main"
 features = "features:main"
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.2",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "scikit-learn",
     "joblib",
     "brotli",
-    "requests",
+    "requests[socks]",
     "pytz",
     "streamlit",
     "altair",

--- a/settle_polymarket.py
+++ b/settle_polymarket.py
@@ -124,7 +124,7 @@ def _parse_position(pos: dict) -> dict | None:
     title_lower = title.lower()
     if "spread" in title_lower or "wins by" in title_lower:
         bet_type = "spread"
-    elif "total" in title_lower or "over" in title_lower or "under" in title_lower:
+    elif "total" in title_lower or "over" in title_lower or "under" in title_lower or "o/u" in title_lower:
         bet_type = "total"
     else:
         bet_type = "game"

--- a/settle_polymarket.py
+++ b/settle_polymarket.py
@@ -11,7 +11,7 @@ import json
 import logging
 import os
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 
 logger = logging.getLogger(__name__)
 
@@ -186,7 +186,7 @@ def settle_to_csv(wallet_address: str | None = None, dry_run: bool = False) -> d
             for row in rows_to_write:
                 writer.writerow(row)
 
-        _write_sync_ts(datetime.utcnow().isoformat())
+        _write_sync_ts(datetime.now(timezone.utc).isoformat())
         print(f"Polymarket: {settled} settled, {skipped} already recorded, {errors} errors")
     elif dry_run:
         print(f"Polymarket (dry run): {settled} would be settled, {skipped} already recorded")

--- a/settle_polymarket.py
+++ b/settle_polymarket.py
@@ -77,8 +77,9 @@ def _parse_position(pos: dict) -> dict | None:
 
     Returns None if the position can't be parsed.
     """
-    # The exact fields depend on CLI output; adapt as needed after discovery.
-    token_id = pos.get("token_id") or pos.get("conditionId") or pos.get("id", "")
+    # Fields per https://docs.polymarket.com/api-reference/core/get-closed-positions-for-a-user
+    token_id = pos.get("conditionId") or pos.get("token_id") or pos.get("id", "")
+    asset = pos.get("asset", "")  # specific token (YES or NO) traded
     title = pos.get("title") or pos.get("question") or pos.get("name", "")
     outcome = pos.get("outcome") or pos.get("result", "")
 
@@ -128,7 +129,7 @@ def _parse_position(pos: dict) -> dict | None:
         "result": result,
         "payout": round(payout, 2),
         "profit": profit,
-        "bet_id": f"poly_{token_id}",
+        "bet_id": f"poly_{token_id}_{outcome or side}_{asset[-8:]}" if asset else f"poly_{token_id}_{outcome or side}",
         "league": "",
     }
 

--- a/settle_polymarket.py
+++ b/settle_polymarket.py
@@ -75,35 +75,49 @@ def _existing_bet_ids() -> set[str]:
 def _parse_position(pos: dict) -> dict | None:
     """Parse a single closed Polymarket position into a CSV-ready dict.
 
+    Uses the documented closed-positions schema:
+    https://docs.polymarket.com/api-reference/core/get-closed-positions-for-a-user
+
+    Key fields: conditionId, asset, outcome, avgPrice, totalBought,
+    realizedPnl, timestamp (int64 epoch seconds).
+
     Returns None if the position can't be parsed.
     """
-    # Fields per https://docs.polymarket.com/api-reference/core/get-closed-positions-for-a-user
     token_id = pos.get("conditionId") or pos.get("token_id") or pos.get("id", "")
-    asset = pos.get("asset", "")  # specific token (YES or NO) traded
+    asset = pos.get("asset", "")
     title = pos.get("title") or pos.get("question") or pos.get("name", "")
     outcome = pos.get("outcome") or pos.get("result", "")
 
-    # Cost and payout
-    cost = pos.get("cost") or pos.get("avgPrice", 0)
-    payout = pos.get("payout") or pos.get("redeemed", 0)
+    # Financial fields -- use realizedPnl as the source of truth for profit.
+    # totalBought is the total USDC spent; avgPrice is per-share.
     try:
-        cost = float(cost)
-        payout = float(payout)
+        realized_pnl = float(pos.get("realizedPnl", 0) or 0)
+        total_bought = float(pos.get("totalBought", 0) or 0)
     except (TypeError, ValueError):
-        cost = 0.0
-        payout = 0.0
+        realized_pnl = 0.0
+        total_bought = 0.0
 
-    profit = round(payout - cost, 2)
+    profit = round(realized_pnl, 2)
+    wager = round(total_bought, 2)
+    payout = round(wager + profit, 2)
     result = "win" if profit > 0 else ("loss" if profit < 0 else "push")
 
-    # Date
+    # Date -- timestamp is int64 epoch seconds per the API docs.
     date_str = ""
-    raw_date = pos.get("created_at") or pos.get("date") or pos.get("timestamp", "")
+    raw_date = pos.get("timestamp") or pos.get("created_at") or pos.get("date", "")
     if raw_date:
         try:
-            dt = datetime.fromisoformat(str(raw_date).replace("Z", "+00:00"))
+            if isinstance(raw_date, (int, float)):
+                dt = datetime.fromtimestamp(raw_date, tz=timezone.utc)
+            else:
+                raw_str = str(raw_date)
+                # Try parsing as epoch integer string first
+                if raw_str.isdigit():
+                    dt = datetime.fromtimestamp(int(raw_str), tz=timezone.utc)
+                else:
+                    dt = datetime.fromisoformat(raw_str.replace("Z", "+00:00"))
             date_str = dt.strftime("%Y-%m-%d")
-        except (ValueError, TypeError):
+        except (ValueError, TypeError, OSError):
             date_str = str(raw_date)[:10]
 
     # Bet type inference from title
@@ -115,7 +129,6 @@ def _parse_position(pos: dict) -> dict | None:
     else:
         bet_type = "game"
 
-    # Side
     side = pos.get("side", "YES").upper()
 
     return {
@@ -125,9 +138,9 @@ def _parse_position(pos: dict) -> dict | None:
         "bet_type": bet_type,
         "line": f"{title} {side}",
         "odds": "n/a",
-        "wager": round(cost, 2),
+        "wager": wager,
         "result": result,
-        "payout": round(payout, 2),
+        "payout": payout,
         "profit": profit,
         "bet_id": f"poly_{token_id}_{outcome or side}_{asset[-8:]}" if asset else f"poly_{token_id}_{outcome or side}",
         "league": "",

--- a/settle_polymarket.py
+++ b/settle_polymarket.py
@@ -1,0 +1,211 @@
+"""Fetch settled Polymarket positions and log them to betting_history.csv.
+
+Uses the Polymarket CLI to query closed positions for a wallet address.
+Mirrors settle_kalshi.py's approach: parse positions, match to pending bets,
+append new rows to the shared CSV ledger.
+"""
+
+import argparse
+import csv
+import json
+import logging
+import os
+import sys
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
+from polymarket.client import PolymarketClient
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+BETTING_HISTORY = os.path.join(BASE_DIR, "data/betting_history.csv")
+SYNC_STATE_FILE = os.path.join(BASE_DIR, ".polymarket_sync_state.json")
+
+CSV_HEADERS = [
+    "date", "platform", "game", "bet_type", "line", "odds",
+    "wager", "result", "payout", "profit", "bet_id", "league",
+]
+
+
+def _read_sync_ts() -> str | None:
+    """Read the last-synced timestamp, or None if never synced."""
+    if not os.path.exists(SYNC_STATE_FILE):
+        return None
+    try:
+        with open(SYNC_STATE_FILE) as f:
+            return json.load(f).get("last_sync_ts")
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _write_sync_ts(ts: str):
+    with open(SYNC_STATE_FILE, "w") as f:
+        json.dump({"last_sync_ts": ts}, f)
+
+
+def _ensure_csv():
+    """Create the CSV file with headers if it doesn't exist."""
+    if not os.path.exists(BETTING_HISTORY):
+        os.makedirs(os.path.dirname(BETTING_HISTORY), exist_ok=True)
+        with open(BETTING_HISTORY, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=CSV_HEADERS)
+            writer.writeheader()
+
+
+def _existing_bet_ids() -> set[str]:
+    """Load all existing bet_id values from the CSV."""
+    ids = set()
+    if not os.path.exists(BETTING_HISTORY):
+        return ids
+    with open(BETTING_HISTORY, newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            bid = row.get("bet_id", "").strip()
+            if bid:
+                ids.add(bid)
+    return ids
+
+
+def _parse_position(pos: dict) -> dict | None:
+    """Parse a single closed Polymarket position into a CSV-ready dict.
+
+    Returns None if the position can't be parsed.
+    """
+    # The exact fields depend on CLI output; adapt as needed after discovery.
+    token_id = pos.get("token_id") or pos.get("conditionId") or pos.get("id", "")
+    title = pos.get("title") or pos.get("question") or pos.get("name", "")
+    outcome = pos.get("outcome") or pos.get("result", "")
+
+    # Cost and payout
+    cost = pos.get("cost") or pos.get("avgPrice", 0)
+    payout = pos.get("payout") or pos.get("redeemed", 0)
+    try:
+        cost = float(cost)
+        payout = float(payout)
+    except (TypeError, ValueError):
+        cost = 0.0
+        payout = 0.0
+
+    profit = round(payout - cost, 2)
+    result = "win" if profit > 0 else ("loss" if profit < 0 else "push")
+
+    # Date
+    date_str = ""
+    raw_date = pos.get("created_at") or pos.get("date") or pos.get("timestamp", "")
+    if raw_date:
+        try:
+            dt = datetime.fromisoformat(str(raw_date).replace("Z", "+00:00"))
+            date_str = dt.strftime("%Y-%m-%d")
+        except (ValueError, TypeError):
+            date_str = str(raw_date)[:10]
+
+    # Bet type inference from title
+    title_lower = title.lower()
+    if "spread" in title_lower or "wins by" in title_lower:
+        bet_type = "spread"
+    elif "total" in title_lower or "over" in title_lower or "under" in title_lower:
+        bet_type = "total"
+    else:
+        bet_type = "game"
+
+    # Side
+    side = pos.get("side", "YES").upper()
+
+    return {
+        "date": date_str,
+        "platform": "Polymarket",
+        "game": title,
+        "bet_type": bet_type,
+        "line": f"{title} {side}",
+        "odds": "n/a",
+        "wager": round(cost, 2),
+        "result": result,
+        "payout": round(payout, 2),
+        "profit": profit,
+        "bet_id": f"poly_{token_id}",
+        "league": "",
+    }
+
+
+def settle_to_csv(wallet_address: str | None = None, dry_run: bool = False) -> dict:
+    """Fetch closed Polymarket positions and append to betting_history.csv.
+
+    Returns summary dict with counts.
+    """
+    wallet = wallet_address or os.getenv("POLYMARKET_WALLET_ADDRESS")
+    if not wallet:
+        print("POLYMARKET_WALLET_ADDRESS not set. Cannot settle Polymarket positions.")
+        return {"settled": 0, "skipped": 0, "errors": 0}
+
+    proxy = os.getenv("POLYMARKET_PROXY")
+    if not proxy:
+        print("POLYMARKET_PROXY not set. Cannot reach Polymarket.")
+        return {"settled": 0, "skipped": 0, "errors": 0}
+
+    client = PolymarketClient(proxy_url=proxy)
+    positions = client.get_closed_positions(wallet)
+
+    if not positions:
+        print("No closed Polymarket positions found.")
+        return {"settled": 0, "skipped": 0, "errors": 0}
+
+    _ensure_csv()
+    existing_ids = _existing_bet_ids()
+
+    settled = 0
+    skipped = 0
+    errors = 0
+
+    rows_to_write = []
+    for pos in positions:
+        try:
+            row = _parse_position(pos)
+            if row is None:
+                errors += 1
+                continue
+
+            if row["bet_id"] in existing_ids:
+                skipped += 1
+                continue
+
+            rows_to_write.append(row)
+            settled += 1
+        except Exception as e:
+            logger.warning("Failed to parse Polymarket position: %s", e)
+            errors += 1
+
+    if rows_to_write and not dry_run:
+        with open(BETTING_HISTORY, "a", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=CSV_HEADERS)
+            for row in rows_to_write:
+                writer.writerow(row)
+
+        _write_sync_ts(datetime.utcnow().isoformat())
+        print(f"Polymarket: {settled} settled, {skipped} already recorded, {errors} errors")
+    elif dry_run:
+        print(f"Polymarket (dry run): {settled} would be settled, {skipped} already recorded")
+        for row in rows_to_write:
+            print(f"  {row['date']} | {row['game'][:50]} | {row['result']} | ${row['profit']:.2f}")
+    else:
+        print("No new Polymarket positions to settle.")
+
+    return {"settled": settled, "skipped": skipped, "errors": errors}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Settle Polymarket positions")
+    parser.add_argument("--wallet", help="Polygon wallet address (overrides env)")
+    parser.add_argument("--dry-run", action="store_true", help="Preview without writing")
+    args = parser.parse_args()
+
+    settle_to_csv(wallet_address=args.wallet, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/settle_polymarket.py
+++ b/settle_polymarket.py
@@ -1,6 +1,6 @@
 """Fetch settled Polymarket positions and log them to betting_history.csv.
 
-Uses the Polymarket CLI to query closed positions for a wallet address.
+Uses the Polymarket Gamma API to query closed positions for a wallet address.
 Mirrors settle_kalshi.py's approach: parse positions, match to pending bets,
 append new rows to the shared CSV ledger.
 """

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -46,6 +46,7 @@ from betting import VALUE_RATINGS
 from kalshi.market_mapper import normalize_team_name
 from settle_bets import settle_pending_bets
 from settle_kalshi import settle_to_csv
+from settle_polymarket import settle_to_csv as settle_polymarket_to_csv
 
 load_dotenv()
 
@@ -2204,6 +2205,17 @@ async def cmd_settle(update: Update, context: ContextTypes.DEFAULT_TYPE):
         except Exception:
             logger.exception("Kalshi settlement fetch failed")
             msg_parts.append("Kalshi: fetch failed")
+
+        # 3) Import settled Polymarket positions
+        try:
+            poly_result = settle_polymarket_to_csv()
+            if poly_result["settled"]:
+                msg_parts.append(f"Polymarket: +{poly_result['settled']} settled")
+            if poly_result["errors"]:
+                msg_parts.append(f"Polymarket: {poly_result['errors']} errors")
+        except Exception:
+            logger.exception("Polymarket settlement fetch failed")
+            msg_parts.append("Polymarket: fetch failed")
 
         await update.message.reply_text("\n".join(msg_parts) if msg_parts else "Nothing new.", reply_markup=MAIN_KEYBOARD)
 

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -2213,9 +2213,9 @@ async def cmd_settle(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 msg_parts.append(f"Polymarket: +{poly_result['settled']} settled")
             if poly_result["errors"]:
                 msg_parts.append(f"Polymarket: {poly_result['errors']} errors")
-        except Exception:
+        except Exception as e:
             logger.exception("Polymarket settlement fetch failed")
-            msg_parts.append("Polymarket: fetch failed")
+            msg_parts.append(f"Polymarket: fetch failed ({type(e).__name__})")
 
         await update.message.reply_text("\n".join(msg_parts) if msg_parts else "Nothing new.", reply_markup=MAIN_KEYBOARD)
 

--- a/tests/test_grade_doubleheader.py
+++ b/tests/test_grade_doubleheader.py
@@ -1,0 +1,109 @@
+"""Tests for doubleheader handling and timezone normalization in grade_predictions.py."""
+
+import pytest
+
+from grade_predictions import match_prediction_to_game
+
+
+class TestDoubleheaderKeying:
+    """When the same matchup appears twice, both games should be retrievable."""
+
+    @pytest.fixture
+    def doubleheader_games(self):
+        """Simulate two games: (Yankees, Red Sox) on same day, different times."""
+        return {
+            ("New York Yankees", "Boston Red Sox"): {
+                "home_score": 3,
+                "away_score": 5,
+                "spread": 0,
+                "home_name": "New York Yankees",
+                "away_name": "Boston Red Sox",
+                "game_time": "13:10",  # Eastern afternoon
+            },
+            ("New York Yankees", "Boston Red Sox", 2): {
+                "home_score": 7,
+                "away_score": 2,
+                "spread": 0,
+                "home_name": "New York Yankees",
+                "away_name": "Boston Red Sox",
+                "game_time": "19:10",  # Eastern evening
+            },
+        }
+
+    def test_single_game_matches_without_time(self):
+        games = {
+            ("Duke Blue Devils", "UNC Tar Heels"): {
+                "home_score": 75,
+                "away_score": 70,
+                "spread": -3.5,
+                "home_name": "Duke Blue Devils",
+                "away_name": "UNC Tar Heels",
+                "game_time": "19:00",
+            },
+        }
+        result = match_prediction_to_game("UNC Tar Heels @ Duke Blue Devils", games)
+        assert result is not None
+        assert result["home_score"] == 75
+
+    def test_doubleheader_without_time_returns_first(self, doubleheader_games):
+        result = match_prediction_to_game(
+            "Boston Red Sox @ New York Yankees",
+            doubleheader_games,
+        )
+        assert result is not None
+        assert result["home_score"] == 3  # First game
+
+    def test_doubleheader_afternoon_game(self, doubleheader_games):
+        result = match_prediction_to_game(
+            "Boston Red Sox @ New York Yankees",
+            doubleheader_games,
+            pred_time="13:10",
+        )
+        assert result is not None
+        assert result["home_score"] == 3  # Afternoon game
+
+    def test_doubleheader_evening_game(self, doubleheader_games):
+        result = match_prediction_to_game(
+            "Boston Red Sox @ New York Yankees",
+            doubleheader_games,
+            pred_time="19:10",
+        )
+        assert result is not None
+        assert result["home_score"] == 7  # Evening game
+
+    def test_doubleheader_closest_time_match(self, doubleheader_games):
+        # 18:00 is closer to 19:10 (70 min) than 13:10 (290 min)
+        result = match_prediction_to_game(
+            "Boston Red Sox @ New York Yankees",
+            doubleheader_games,
+            pred_time="18:00",
+        )
+        assert result is not None
+        assert result["home_score"] == 7  # Evening game is closer
+
+    def test_no_match_returns_none(self, doubleheader_games):
+        result = match_prediction_to_game(
+            "Chicago Cubs @ Los Angeles Dodgers",
+            doubleheader_games,
+        )
+        assert result is None
+
+
+class TestFuzzyMatching:
+    """Fuzzy name matching still works with new keying."""
+
+    def test_partial_name_match(self):
+        games = {
+            ("UConn Huskies", "Providence Friars"): {
+                "home_score": 80,
+                "away_score": 65,
+                "spread": -7.5,
+                "home_name": "UConn Huskies",
+                "away_name": "Providence Friars",
+                "game_time": "19:00",
+            },
+        }
+        # Prediction uses short name, game uses full name
+        result = match_prediction_to_game("Providence @ UConn Huskies", games)
+        assert result is not None
+        assert result["home_score"] == 80

--- a/tests/test_polymarket_client.py
+++ b/tests/test_polymarket_client.py
@@ -1,159 +1,201 @@
-"""Tests for polymarket.client CLI wrapper."""
+"""Tests for polymarket.client Gamma + CLOB API wrapper."""
 
 import json
-import subprocess
 
 import pytest
+import requests
 
-from polymarket.client import PolymarketClient
+from polymarket.client import PolymarketClient, GAMMA_BASE, CLOB_BASE, SPORT_TAG_IDS
 
 
-class TestRunCli:
-    """Tests for the core _run_cli subprocess wrapper."""
+class _FakeResponse:
+    """Minimal requests.Response stand-in."""
 
-    def test_returns_parsed_json_list(self, monkeypatch):
-        payload = [{"id": "1", "question": "Test?"}]
+    def __init__(self, json_data, status_code=200):
+        self._json = json_data
+        self.status_code = status_code
+        self.headers = {"content-type": "application/json"}
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(response=self)
+
+
+class TestGet:
+    """Core _get method error handling."""
+
+    def test_returns_parsed_json(self, monkeypatch):
+        payload = [{"id": "1", "title": "Test"}]
         monkeypatch.setattr(
-            subprocess, "run",
-            lambda *a, **kw: subprocess.CompletedProcess(
-                a[0], 0, stdout=json.dumps(payload), stderr=""
-            ),
+            requests.Session, "get",
+            lambda self, url, **kw: _FakeResponse(payload),
         )
-        client = PolymarketClient(cli_path="polymarket")
-        result = client._run_cli(["markets", "list"])
-        assert result == payload
+        client = PolymarketClient(proxy_url=None)
+        assert client._get(f"{GAMMA_BASE}/events") == payload
 
-    def test_returns_parsed_json_dict(self, monkeypatch):
-        payload = {"mid": "0.55"}
-        monkeypatch.setattr(
-            subprocess, "run",
-            lambda *a, **kw: subprocess.CompletedProcess(
-                a[0], 0, stdout=json.dumps(payload), stderr=""
-            ),
-        )
-        client = PolymarketClient()
-        result = client._run_cli(["clob", "midpoint", "TOKEN"])
-        assert result == payload
-
-    def test_returns_empty_list_on_cli_not_found(self, monkeypatch):
+    def test_returns_empty_on_request_error(self, monkeypatch):
         def _raise(*a, **kw):
-            raise FileNotFoundError("polymarket not found")
-        monkeypatch.setattr(subprocess, "run", _raise)
-        client = PolymarketClient()
-        assert client._run_cli(["markets", "list"]) == []
+            raise requests.ConnectionError("no connection")
+        monkeypatch.setattr(requests.Session, "get", _raise)
+        client = PolymarketClient(proxy_url=None)
+        assert client._get(f"{GAMMA_BASE}/events") == []
 
-    def test_returns_empty_list_on_timeout(self, monkeypatch):
-        def _raise(*a, **kw):
-            raise subprocess.TimeoutExpired("polymarket", 30)
-        monkeypatch.setattr(subprocess, "run", _raise)
-        client = PolymarketClient(timeout=1)
-        assert client._run_cli(["clob", "ok"]) == []
-
-    def test_returns_empty_on_invalid_json(self, monkeypatch):
+    def test_returns_empty_on_http_error(self, monkeypatch):
         monkeypatch.setattr(
-            subprocess, "run",
-            lambda *a, **kw: subprocess.CompletedProcess(
-                a[0], 0, stdout="not json {{{", stderr=""
-            ),
+            requests.Session, "get",
+            lambda self, url, **kw: _FakeResponse({}, status_code=500),
         )
-        client = PolymarketClient()
-        assert client._run_cli(["markets", "list"]) == []
-
-    def test_returns_empty_list_on_nonzero_exit_no_stdout(self, monkeypatch):
-        monkeypatch.setattr(
-            subprocess, "run",
-            lambda *a, **kw: subprocess.CompletedProcess(
-                a[0], 1, stdout="", stderr="error"
-            ),
-        )
-        client = PolymarketClient()
-        assert client._run_cli(["clob", "ok"]) == []
+        client = PolymarketClient(proxy_url=None)
+        assert client._get(f"{GAMMA_BASE}/events") == []
 
 
-class TestProxyEnv:
-    """Verify proxy env vars are set in subprocess calls."""
+class TestProxyConfig:
+    """Verify proxy configuration on session."""
 
-    def test_proxy_env_vars_set(self, monkeypatch):
-        captured_env = {}
-
-        def fake_run(*args, **kwargs):
-            captured_env.update(kwargs.get("env", {}))
-            return subprocess.CompletedProcess(args[0], 0, stdout="[]", stderr="")
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
-        client = PolymarketClient(proxy_url="socks5://127.0.0.1:8080")
-        client._run_cli(["markets", "list"])
-
-        assert captured_env.get("HTTPS_PROXY") == "socks5://127.0.0.1:8080"
-        assert captured_env.get("HTTP_PROXY") == "socks5://127.0.0.1:8080"
-        assert captured_env.get("ALL_PROXY") == "socks5://127.0.0.1:8080"
+    def test_proxy_set_from_constructor(self):
+        client = PolymarketClient(proxy_url="socks5h://127.0.0.1:8080")
+        assert client.session.proxies["https"] == "socks5h://127.0.0.1:8080"
+        assert client.session.proxies["http"] == "socks5h://127.0.0.1:8080"
 
     def test_no_proxy_when_none(self, monkeypatch):
-        captured_env = {}
-
-        def fake_run(*args, **kwargs):
-            captured_env.update(kwargs.get("env", {}))
-            return subprocess.CompletedProcess(args[0], 0, stdout="[]", stderr="")
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
         monkeypatch.delenv("POLYMARKET_PROXY", raising=False)
         client = PolymarketClient(proxy_url=None)
-        client._run_cli(["markets", "list"])
+        assert not client.session.proxies
 
-        # Should not have injected proxy vars (beyond what's in os.environ)
-        assert "ALL_PROXY" not in captured_env or captured_env["ALL_PROXY"] != "socks5://127.0.0.1:8080"
+
+class TestGetSportsGameMarkets:
+    """Test game market fetching and flattening."""
+
+    def test_flattens_event_markets(self, monkeypatch):
+        events = [{
+            "title": "Yankees vs Red Sox",
+            "gameId": "12345",
+            "startTime": "2026-04-10T23:00:00Z",
+            "slug": "mlb-nyy-bos-2026-04-10",
+            "teams": [
+                {"name": "New York Yankees", "abbreviation": "nyy"},
+                {"name": "Boston Red Sox", "abbreviation": "bos"},
+            ],
+            "markets": [
+                {
+                    "question": "New York Yankees vs. Boston Red Sox",
+                    "outcomes": '["New York Yankees", "Boston Red Sox"]',
+                    "outcomePrices": '["0.55", "0.45"]',
+                    "clobTokenIds": '["token_yes", "token_no"]',
+                    "conditionId": "0xabc",
+                    "slug": "mlb-nyy-bos-2026-04-10",
+                },
+                {
+                    "question": "Spread: Boston Red Sox (-1.5)",
+                    "outcomes": '["Boston Red Sox", "New York Yankees"]',
+                    "outcomePrices": '["0.48", "0.52"]',
+                    "clobTokenIds": '["tok_sp_yes", "tok_sp_no"]',
+                    "conditionId": "0xdef",
+                    "slug": "mlb-nyy-bos-2026-04-10-spread-home-1pt5",
+                },
+            ],
+        }]
+        monkeypatch.setattr(
+            requests.Session, "get",
+            lambda self, url, **kw: _FakeResponse(events),
+        )
+        client = PolymarketClient(proxy_url=None)
+        markets = client.get_sports_game_markets("MLB")
+
+        assert len(markets) == 2
+        # JSON strings should be parsed
+        assert markets[0]["outcomes"] == ["New York Yankees", "Boston Red Sox"]
+        assert markets[0]["outcomePrices"] == ["0.55", "0.45"]
+        assert markets[0]["clobTokenIds"] == ["token_yes", "token_no"]
+        # Event metadata should be attached
+        assert markets[0]["event_teams"][0]["name"] == "New York Yankees"
+        assert markets[0]["event_start_time"] == "2026-04-10T23:00:00Z"
+
+    def test_skips_non_game_events(self, monkeypatch):
+        events = [
+            {"title": "MLB World Series Champion 2026", "markets": [{"question": "Will Yankees win?"}]},
+            {"title": "Some futures", "gameId": None, "teams": None, "markets": []},
+        ]
+        monkeypatch.setattr(
+            requests.Session, "get",
+            lambda self, url, **kw: _FakeResponse(events),
+        )
+        client = PolymarketClient(proxy_url=None)
+        markets = client.get_sports_game_markets("MLB")
+        assert len(markets) == 0
+
+    def test_unknown_league_returns_empty(self, monkeypatch):
+        client = PolymarketClient(proxy_url=None)
+        assert client.get_sports_game_markets("CURLING") == []
 
 
 class TestMarketPrices:
-    """Tests for price normalization to 0-100 cent scale."""
+    """Price normalization to 0-100 cent scale."""
 
     def test_midpoint_converted_to_cents(self, monkeypatch):
-        call_count = [0]
-
-        def fake_run(*args, **kwargs):
-            call_count[0] += 1
-            # First call: midpoint
-            return subprocess.CompletedProcess(
-                args[0], 0,
-                stdout=json.dumps({"mid": "0.43"}),
-                stderr="",
-            )
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
-        client = PolymarketClient()
+        monkeypatch.setattr(
+            requests.Session, "get",
+            lambda self, url, **kw: _FakeResponse({"mid": "0.43"}),
+        )
+        client = PolymarketClient(proxy_url=None)
         prices = client.get_market_prices("TOKEN123", title="Test")
-
         assert prices["yes_price"] == 43.0
         assert prices["no_price"] == 57.0
-        assert prices["token_id"] == "TOKEN123"
-        assert prices["title"] == "Test"
 
     def test_fallback_to_buy_price(self, monkeypatch):
-        calls = []
-
-        def fake_run(*args, **kwargs):
-            cmd = args[0]
-            calls.append(cmd)
-            if "midpoint" in cmd:
-                return subprocess.CompletedProcess(cmd, 0, stdout="{}", stderr="")
-            if "price" in cmd:
-                return subprocess.CompletedProcess(
-                    cmd, 0, stdout=json.dumps({"price": "0.70"}), stderr=""
-                )
-            return subprocess.CompletedProcess(cmd, 0, stdout="{}", stderr="")
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
-        client = PolymarketClient()
+        call_count = [0]
+        def fake_get(self, url, **kw):
+            call_count[0] += 1
+            if "midpoint" in url:
+                return _FakeResponse({})
+            if "price" in url:
+                return _FakeResponse({"price": "0.70"})
+            return _FakeResponse({})
+        monkeypatch.setattr(requests.Session, "get", fake_get)
+        client = PolymarketClient(proxy_url=None)
         prices = client.get_market_prices("TOKEN")
         assert prices["yes_price"] == 70.0
         assert prices["no_price"] == 30.0
 
     def test_returns_none_when_no_prices(self, monkeypatch):
         monkeypatch.setattr(
-            subprocess, "run",
-            lambda *a, **kw: subprocess.CompletedProcess(a[0], 0, stdout="{}", stderr=""),
+            requests.Session, "get",
+            lambda self, url, **kw: _FakeResponse({}),
         )
-        client = PolymarketClient()
+        client = PolymarketClient(proxy_url=None)
         prices = client.get_market_prices("TOKEN")
         assert prices["yes_price"] is None
         assert prices["no_price"] is None
+
+
+class TestSportTagIds:
+    """Verify sport tag ID mapping."""
+
+    def test_mlb_tag_id(self):
+        assert SPORT_TAG_IDS["MLB"] == "100381"
+
+    def test_ncaab_tag_id(self):
+        assert SPORT_TAG_IDS["NCAAB"] == "100149"
+
+
+class TestConnectivity:
+    """Geoblock and health checks."""
+
+    def test_geoblock_returns_dict(self, monkeypatch):
+        monkeypatch.setattr(
+            requests.Session, "get",
+            lambda self, url, **kw: _FakeResponse({"blocked": False, "country": "ID"}),
+        )
+        client = PolymarketClient(proxy_url=None)
+        result = client.check_geoblock()
+        assert result["blocked"] is False
+
+    def test_is_ok_returns_true(self, monkeypatch):
+        resp = _FakeResponse("OK")
+        resp.status_code = 200
+        monkeypatch.setattr(requests.Session, "get", lambda self, url, **kw: resp)
+        client = PolymarketClient(proxy_url=None)
+        assert client.is_ok() is True

--- a/tests/test_polymarket_client.py
+++ b/tests/test_polymarket_client.py
@@ -1,0 +1,159 @@
+"""Tests for polymarket.client CLI wrapper."""
+
+import json
+import subprocess
+
+import pytest
+
+from polymarket.client import PolymarketClient
+
+
+class TestRunCli:
+    """Tests for the core _run_cli subprocess wrapper."""
+
+    def test_returns_parsed_json_list(self, monkeypatch):
+        payload = [{"id": "1", "question": "Test?"}]
+        monkeypatch.setattr(
+            subprocess, "run",
+            lambda *a, **kw: subprocess.CompletedProcess(
+                a[0], 0, stdout=json.dumps(payload), stderr=""
+            ),
+        )
+        client = PolymarketClient(cli_path="polymarket")
+        result = client._run_cli(["markets", "list"])
+        assert result == payload
+
+    def test_returns_parsed_json_dict(self, monkeypatch):
+        payload = {"mid": "0.55"}
+        monkeypatch.setattr(
+            subprocess, "run",
+            lambda *a, **kw: subprocess.CompletedProcess(
+                a[0], 0, stdout=json.dumps(payload), stderr=""
+            ),
+        )
+        client = PolymarketClient()
+        result = client._run_cli(["clob", "midpoint", "TOKEN"])
+        assert result == payload
+
+    def test_returns_empty_list_on_cli_not_found(self, monkeypatch):
+        def _raise(*a, **kw):
+            raise FileNotFoundError("polymarket not found")
+        monkeypatch.setattr(subprocess, "run", _raise)
+        client = PolymarketClient()
+        assert client._run_cli(["markets", "list"]) == []
+
+    def test_returns_empty_list_on_timeout(self, monkeypatch):
+        def _raise(*a, **kw):
+            raise subprocess.TimeoutExpired("polymarket", 30)
+        monkeypatch.setattr(subprocess, "run", _raise)
+        client = PolymarketClient(timeout=1)
+        assert client._run_cli(["clob", "ok"]) == []
+
+    def test_returns_empty_on_invalid_json(self, monkeypatch):
+        monkeypatch.setattr(
+            subprocess, "run",
+            lambda *a, **kw: subprocess.CompletedProcess(
+                a[0], 0, stdout="not json {{{", stderr=""
+            ),
+        )
+        client = PolymarketClient()
+        assert client._run_cli(["markets", "list"]) == []
+
+    def test_returns_empty_list_on_nonzero_exit_no_stdout(self, monkeypatch):
+        monkeypatch.setattr(
+            subprocess, "run",
+            lambda *a, **kw: subprocess.CompletedProcess(
+                a[0], 1, stdout="", stderr="error"
+            ),
+        )
+        client = PolymarketClient()
+        assert client._run_cli(["clob", "ok"]) == []
+
+
+class TestProxyEnv:
+    """Verify proxy env vars are set in subprocess calls."""
+
+    def test_proxy_env_vars_set(self, monkeypatch):
+        captured_env = {}
+
+        def fake_run(*args, **kwargs):
+            captured_env.update(kwargs.get("env", {}))
+            return subprocess.CompletedProcess(args[0], 0, stdout="[]", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        client = PolymarketClient(proxy_url="socks5://127.0.0.1:8080")
+        client._run_cli(["markets", "list"])
+
+        assert captured_env.get("HTTPS_PROXY") == "socks5://127.0.0.1:8080"
+        assert captured_env.get("HTTP_PROXY") == "socks5://127.0.0.1:8080"
+        assert captured_env.get("ALL_PROXY") == "socks5://127.0.0.1:8080"
+
+    def test_no_proxy_when_none(self, monkeypatch):
+        captured_env = {}
+
+        def fake_run(*args, **kwargs):
+            captured_env.update(kwargs.get("env", {}))
+            return subprocess.CompletedProcess(args[0], 0, stdout="[]", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.delenv("POLYMARKET_PROXY", raising=False)
+        client = PolymarketClient(proxy_url=None)
+        client._run_cli(["markets", "list"])
+
+        # Should not have injected proxy vars (beyond what's in os.environ)
+        assert "ALL_PROXY" not in captured_env or captured_env["ALL_PROXY"] != "socks5://127.0.0.1:8080"
+
+
+class TestMarketPrices:
+    """Tests for price normalization to 0-100 cent scale."""
+
+    def test_midpoint_converted_to_cents(self, monkeypatch):
+        call_count = [0]
+
+        def fake_run(*args, **kwargs):
+            call_count[0] += 1
+            # First call: midpoint
+            return subprocess.CompletedProcess(
+                args[0], 0,
+                stdout=json.dumps({"mid": "0.43"}),
+                stderr="",
+            )
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        client = PolymarketClient()
+        prices = client.get_market_prices("TOKEN123", title="Test")
+
+        assert prices["yes_price"] == 43.0
+        assert prices["no_price"] == 57.0
+        assert prices["token_id"] == "TOKEN123"
+        assert prices["title"] == "Test"
+
+    def test_fallback_to_buy_price(self, monkeypatch):
+        calls = []
+
+        def fake_run(*args, **kwargs):
+            cmd = args[0]
+            calls.append(cmd)
+            if "midpoint" in cmd:
+                return subprocess.CompletedProcess(cmd, 0, stdout="{}", stderr="")
+            if "price" in cmd:
+                return subprocess.CompletedProcess(
+                    cmd, 0, stdout=json.dumps({"price": "0.70"}), stderr=""
+                )
+            return subprocess.CompletedProcess(cmd, 0, stdout="{}", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        client = PolymarketClient()
+        prices = client.get_market_prices("TOKEN")
+        assert prices["yes_price"] == 70.0
+        assert prices["no_price"] == 30.0
+
+    def test_returns_none_when_no_prices(self, monkeypatch):
+        monkeypatch.setattr(
+            subprocess, "run",
+            lambda *a, **kw: subprocess.CompletedProcess(a[0], 0, stdout="{}", stderr=""),
+        )
+        client = PolymarketClient()
+        prices = client.get_market_prices("TOKEN")
+        assert prices["yes_price"] is None
+        assert prices["no_price"] is None

--- a/tests/test_polymarket_ev.py
+++ b/tests/test_polymarket_ev.py
@@ -1,0 +1,96 @@
+"""Tests for Polymarket fee model in betting.ev_calculator."""
+
+import pytest
+
+from betting.ev_calculator import (
+    POLYMARKET_TAKER_FEE_COEFF,
+    polymarket_fee_cents,
+    polymarket_implied_prob,
+    analyze_polymarket_bet,
+    kalshi_fee_cents,
+    kalshi_implied_prob,
+    EdgeRating,
+)
+
+
+class TestPolymarketFeeCoefficient:
+    """The sports fee coefficient should be 3%."""
+
+    def test_coefficient_is_three_percent(self):
+        assert POLYMARKET_TAKER_FEE_COEFF == 0.03
+
+
+class TestPolymarketFeeCents:
+    """Fee formula: 0.03 * P * (1-P) * 100."""
+
+    def test_fee_at_50c_peak(self):
+        fee = polymarket_fee_cents(50.0)
+        assert abs(fee - 0.75) < 0.001
+
+    def test_fee_at_30c(self):
+        fee = polymarket_fee_cents(30.0)
+        expected = 0.03 * 0.3 * 0.7 * 100
+        assert abs(fee - expected) < 0.001
+
+    def test_fee_at_0c_is_zero(self):
+        assert polymarket_fee_cents(0.0) == 0.0
+
+    def test_fee_at_100c_is_zero(self):
+        assert polymarket_fee_cents(100.0) == 0.0
+
+    def test_fee_symmetric(self):
+        assert abs(polymarket_fee_cents(30.0) - polymarket_fee_cents(70.0)) < 0.001
+
+
+class TestPolymarketImpliedProb:
+    """Implied prob = price/100 + fee adjustment."""
+
+    def test_at_50c(self):
+        prob = polymarket_implied_prob(50.0)
+        # 0.50 + 0.03 * 0.5 * 0.5 = 0.5075
+        assert abs(prob - 0.5075) < 0.0001
+
+    def test_at_70c(self):
+        prob = polymarket_implied_prob(70.0)
+        expected = 0.70 + 0.03 * 0.7 * 0.3
+        assert abs(prob - expected) < 0.0001
+
+    def test_cheaper_than_kalshi(self):
+        """Polymarket 3% fee should always produce lower implied prob than Kalshi 7%."""
+        for price in [20, 30, 40, 50, 60, 70, 80]:
+            poly = polymarket_implied_prob(float(price))
+            kalshi = kalshi_implied_prob(float(price))
+            assert poly < kalshi, f"At {price}c: Poly {poly:.4f} >= Kalshi {kalshi:.4f}"
+
+    def test_more_edge_than_kalshi(self):
+        """Same model prob should yield more edge on Polymarket due to lower fees."""
+        model_prob = 0.60
+        poly_edge = model_prob - polymarket_implied_prob(50.0)
+        kalshi_edge = model_prob - kalshi_implied_prob(50.0)
+        assert poly_edge > kalshi_edge
+
+
+class TestAnalyzePolymarketBet:
+    """Full bet analysis with fee-adjusted pricing."""
+
+    def test_strong_edge_returns_strong(self):
+        result = analyze_polymarket_bet(model_prob=0.65, poly_yes_price=50.0)
+        assert result["rating"] == EdgeRating.STRONG
+
+    def test_no_edge_returns_pass(self):
+        result = analyze_polymarket_bet(model_prob=0.50, poly_yes_price=50.0)
+        assert result["rating"] == EdgeRating.PASS
+
+    def test_edge_is_positive_when_model_exceeds_implied(self):
+        result = analyze_polymarket_bet(model_prob=0.60, poly_yes_price=50.0)
+        assert result["edge"] > 0
+        assert result["edge_pct"] > 0
+
+    def test_ev_positive_for_value_bet(self):
+        result = analyze_polymarket_bet(model_prob=0.65, poly_yes_price=50.0)
+        assert result["ev"] > 0
+
+    def test_returns_all_expected_keys(self):
+        result = analyze_polymarket_bet(model_prob=0.55, poly_yes_price=45.0)
+        for key in ("edge", "edge_pct", "rating", "implied_prob", "model_prob", "ev"):
+            assert key in result

--- a/tests/test_polymarket_mapper.py
+++ b/tests/test_polymarket_mapper.py
@@ -1,0 +1,299 @@
+"""Tests for polymarket.market_mapper field detection, team matching, and game_time disambiguation."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from polymarket.market_mapper import PolymarketMarketMapper
+
+
+# -- Fixtures --
+
+def _make_market(title, date_str=None, market_type=None, outcomes=None,
+                 prices=None, token_id=None):
+    """Helper to build a market dict matching common Polymarket schemas."""
+    m = {"question": title}
+    if date_str:
+        m["game_start_time"] = date_str
+    if market_type:
+        m["market_type"] = market_type
+    if outcomes:
+        m["outcomes"] = outcomes
+    if prices:
+        m["outcomePrices"] = prices
+    if token_id:
+        m["clobTokenIds"] = [token_id]
+    return m
+
+
+DUKE_UNC_GAME = _make_market(
+    "Will Duke beat UNC?",
+    date_str="2026-04-09T23:00:00Z",
+    market_type="moneyline",
+    outcomes=["Duke", "UNC"],
+    prices=["0.55", "0.45"],
+    token_id="tok_duke_unc_game",
+)
+
+DUKE_UNC_SPREAD = _make_market(
+    "Duke -5.5 vs UNC",
+    date_str="2026-04-09T23:00:00Z",
+    market_type="spread",
+    prices=["0.48", "0.52"],
+    token_id="tok_duke_unc_spread",
+)
+
+DUKE_UNC_TOMORROW = _make_market(
+    "Will Duke beat UNC?",
+    date_str="2026-04-10T23:00:00Z",
+    market_type="moneyline",
+    prices=["0.60", "0.40"],
+    token_id="tok_duke_unc_tmrw",
+)
+
+
+class TestFieldDetection:
+    """Auto-detection of JSON field names from market dicts."""
+
+    def test_detects_question_field(self):
+        mapper = PolymarketMarketMapper([{"question": "Test?", "id": "1"}])
+        assert mapper._f_title == "question"
+
+    def test_detects_title_field(self):
+        mapper = PolymarketMarketMapper([{"title": "Test?", "id": "1"}])
+        assert mapper._f_title == "title"
+
+    def test_detects_clob_token_ids(self):
+        mapper = PolymarketMarketMapper([{"question": "T", "clobTokenIds": ["a", "b"]}])
+        assert mapper._f_token == "clobTokenIds"
+
+    def test_flattens_nested_events(self):
+        event = {
+            "title": "Duke vs UNC",
+            "markets": [
+                {"question": "Will Duke win?", "id": "m1"},
+                {"question": "Duke spread", "id": "m2"},
+            ],
+        }
+        mapper = PolymarketMarketMapper([event])
+        assert len(mapper.markets) == 2
+        assert mapper.markets[0].get("_event", {}).get("title") == "Duke vs UNC"
+
+
+class TestDateParsing:
+    """Tests for _get_date with various formats."""
+
+    def test_iso_z_suffix_preserves_utc(self):
+        m = {"question": "T", "game_start_time": "2026-04-09T19:00:00Z"}
+        mapper = PolymarketMarketMapper([m])
+        dt = mapper._get_date(m)
+        assert dt is not None
+        assert dt.tzinfo is not None
+        assert dt.hour == 19
+
+    def test_unix_timestamp_returns_utc(self):
+        m = {"question": "T", "game_start_time": 1776000000}
+        mapper = PolymarketMarketMapper([m])
+        dt = mapper._get_date(m)
+        assert dt is not None
+        assert dt.tzinfo is not None
+
+    def test_naive_iso_returns_naive(self):
+        m = {"question": "T", "game_start_time": "2026-04-09T19:00:00"}
+        mapper = PolymarketMarketMapper([m])
+        dt = mapper._get_date(m)
+        assert dt is not None
+        assert dt.tzinfo is None
+        assert dt.hour == 19
+
+    def test_date_only(self):
+        m = {"question": "T", "game_start_time": "2026-04-09"}
+        mapper = PolymarketMarketMapper([m])
+        dt = mapper._get_date(m)
+        assert dt is not None
+        assert dt.day == 9
+
+
+class TestTeamMatching:
+    """Tests for _teams_match with keywords and abbreviation variants."""
+
+    def test_both_teams_in_title(self):
+        mapper = PolymarketMarketMapper([DUKE_UNC_GAME])
+        assert mapper._teams_match(DUKE_UNC_GAME, "duke", "unc")
+
+    def test_partial_match_fails(self):
+        mapper = PolymarketMarketMapper([DUKE_UNC_GAME])
+        assert not mapper._teams_match(DUKE_UNC_GAME, "duke", "kentucky")
+
+    def test_state_abbreviation_variant(self):
+        m = _make_market("Ohio State vs Michigan")
+        mapper = PolymarketMarketMapper([m])
+        assert mapper._teams_match(m, "ohio st.", "michigan")
+
+    def test_saint_abbreviation_variant(self):
+        m = _make_market("St. John's vs Villanova")
+        mapper = PolymarketMarketMapper([m])
+        assert mapper._teams_match(m, "saint john", "villanova")
+
+
+class TestFindAllMarketsForGame:
+    """Tests for find_all_markets_for_game with date filtering."""
+
+    def test_finds_same_day_markets(self):
+        mapper = PolymarketMarketMapper([DUKE_UNC_GAME, DUKE_UNC_SPREAD])
+        game_date = datetime(2026, 4, 9)
+        matches = mapper.find_all_markets_for_game("Duke", "UNC", game_date)
+        assert len(matches) == 2
+
+    def test_excludes_wrong_date(self):
+        # Apr 12 is 3 days from Apr 9, beyond the 1-day tolerance
+        far_market = _make_market(
+            "Will Duke beat UNC?",
+            date_str="2026-04-12T23:00:00Z",
+            market_type="moneyline",
+            token_id="tok_duke_unc_far",
+        )
+        mapper = PolymarketMarketMapper([DUKE_UNC_GAME, far_market])
+        game_date = datetime(2026, 4, 9)
+        matches = mapper.find_all_markets_for_game("Duke", "UNC", game_date)
+        assert len(matches) == 1
+        assert mapper._get_token_id(matches[0]) == "tok_duke_unc_game"
+
+    def test_one_day_tolerance(self):
+        mapper = PolymarketMarketMapper([DUKE_UNC_TOMORROW])
+        game_date = datetime(2026, 4, 9)
+        matches = mapper.find_all_markets_for_game("Duke", "UNC", game_date)
+        assert len(matches) == 1  # Apr 10 is within 1 day of Apr 9
+
+
+class TestFindGameMarket:
+    """Tests for find_game_market filtering to moneyline type."""
+
+    def test_finds_game_market_not_spread(self):
+        mapper = PolymarketMarketMapper([DUKE_UNC_GAME, DUKE_UNC_SPREAD])
+        result = mapper.find_game_market("Duke", "UNC", datetime(2026, 4, 9))
+        assert result is not None
+        assert mapper._get_token_id(result) == "tok_duke_unc_game"
+
+    def test_returns_none_when_no_game_market(self):
+        mapper = PolymarketMarketMapper([DUKE_UNC_SPREAD])
+        result = mapper.find_game_market("Duke", "UNC", datetime(2026, 4, 9))
+        assert result is None
+
+
+class TestFindSpreadMarket:
+    """Tests for find_spread_market with spread value matching."""
+
+    def test_finds_spread_market(self):
+        mapper = PolymarketMarketMapper([DUKE_UNC_GAME, DUKE_UNC_SPREAD])
+        result = mapper.find_spread_market("Duke", "UNC", datetime(2026, 4, 9), -5.5)
+        assert result is not None
+        assert mapper._get_token_id(result) == "tok_duke_unc_spread"
+
+
+class TestGameTimeDisambiguation:
+    """Tests for doubleheader resolution via game_time parameter."""
+
+    @pytest.fixture
+    def doubleheader_markets(self):
+        game1 = _make_market(
+            "Will Yankees beat Red Sox?",
+            date_str="2026-07-15T17:10:00Z",
+            market_type="moneyline",
+            token_id="tok_g1",
+        )
+        game2 = _make_market(
+            "Will Yankees beat Red Sox?",
+            date_str="2026-07-15T23:10:00Z",
+            market_type="moneyline",
+            token_id="tok_g2",
+        )
+        return [game1, game2]
+
+    def test_without_game_time_returns_first(self, doubleheader_markets):
+        mapper = PolymarketMarketMapper(doubleheader_markets)
+        result = mapper.find_game_market(
+            "Yankees", "Red Sox", datetime(2026, 7, 15),
+        )
+        assert mapper._get_token_id(result) == "tok_g1"
+
+    def test_game_time_picks_afternoon_game(self, doubleheader_markets):
+        mapper = PolymarketMarketMapper(doubleheader_markets)
+        result = mapper.find_game_market(
+            "Yankees", "Red Sox", datetime(2026, 7, 15),
+            game_time="17:10",
+        )
+        assert mapper._get_token_id(result) == "tok_g1"
+
+    def test_game_time_picks_evening_game(self, doubleheader_markets):
+        mapper = PolymarketMarketMapper(doubleheader_markets)
+        result = mapper.find_game_market(
+            "Yankees", "Red Sox", datetime(2026, 7, 15),
+            game_time="23:10",
+        )
+        assert mapper._get_token_id(result) == "tok_g2"
+
+    def test_game_time_picks_closest(self, doubleheader_markets):
+        mapper = PolymarketMarketMapper(doubleheader_markets)
+        # 20:00 is closer to 17:10 (170 min) than 23:10 (190 min)
+        result = mapper.find_game_market(
+            "Yankees", "Red Sox", datetime(2026, 7, 15),
+            game_time="20:00",
+        )
+        assert mapper._get_token_id(result) == "tok_g1"
+
+
+class TestTimeDistanceUTC:
+    """Verify _time_distance normalizes timezone-aware market times to UTC."""
+
+    def test_utc_aware_market_time(self):
+        m = _make_market("T", date_str="2026-04-09T19:00:00Z")
+        mapper = PolymarketMarketMapper([m])
+        dist = mapper._time_distance(m, "19:00")
+        assert dist == 0
+
+    def test_naive_market_time_treated_as_utc(self):
+        m = _make_market("T", date_str="2026-04-09T19:00:00")
+        mapper = PolymarketMarketMapper([m])
+        dist = mapper._time_distance(m, "19:00")
+        assert dist == 0
+
+    def test_offset_aware_market_time_converted(self):
+        # Market time is 15:00 EST = 20:00 UTC
+        m = {"question": "T", "game_start_time": "2026-04-09T15:00:00-05:00"}
+        mapper = PolymarketMarketMapper([m])
+        dist = mapper._time_distance(m, "20:00")
+        assert dist == 0
+
+
+class TestInferYesTeam:
+    """Tests for yes-team inference from market title/outcomes."""
+
+    def test_infer_from_beat_pattern(self):
+        mapper = PolymarketMarketMapper([DUKE_UNC_GAME])
+        result = mapper.infer_yes_team(DUKE_UNC_GAME, "Duke", "UNC")
+        assert result == "Duke"
+
+    def test_infer_from_outcomes_list(self):
+        m = _make_market("Game winner?", outcomes=["Kansas", "Baylor"])
+        mapper = PolymarketMarketMapper([m])
+        result = mapper.infer_yes_team(m, "Kansas", "Baylor")
+        assert result == "Kansas"
+
+    def test_returns_none_when_ambiguous(self):
+        m = _make_market("Some generic title")
+        mapper = PolymarketMarketMapper([m])
+        result = mapper.infer_yes_team(m, "TeamA", "TeamB")
+        assert result is None
+
+
+class TestGetMarketPrices:
+    """Tests for price extraction in 0-100 cent scale."""
+
+    def test_extracts_prices_from_outcome_prices(self):
+        mapper = PolymarketMarketMapper([DUKE_UNC_GAME])
+        prices = mapper.get_market_prices(DUKE_UNC_GAME)
+        assert prices["yes_price"] == 55.0
+        assert prices["no_price"] == 45.0
+        assert prices["token_id"] == "tok_duke_unc_game"
+        assert "Duke" in prices["title"]

--- a/tests/test_settle_polymarket.py
+++ b/tests/test_settle_polymarket.py
@@ -1,0 +1,241 @@
+"""Tests for settle_polymarket position parsing and CSV writing."""
+
+import csv
+import os
+import pytest
+
+from settle_polymarket import _parse_position, _existing_bet_ids, settle_to_csv
+
+
+class TestParsePosition:
+    """Tests for _parse_position against the documented closed-positions schema."""
+
+    def _pos(self, **overrides):
+        base = {
+            "conditionId": "0xabc123",
+            "asset": "98765432109876543210",
+            "title": "New York Yankees vs. Boston Red Sox",
+            "outcome": "YES",
+            "avgPrice": 0.45,
+            "totalBought": 10.0,
+            "realizedPnl": 5.50,
+            "timestamp": 1744300800,  # 2025-04-10 16:00:00 UTC
+            "side": "YES",
+        }
+        base.update(overrides)
+        return base
+
+    def test_winning_position(self):
+        row = _parse_position(self._pos(realizedPnl=5.50, totalBought=10.0))
+        assert row["result"] == "win"
+        assert row["profit"] == 5.50
+        assert row["wager"] == 10.0
+        assert row["payout"] == 15.50
+
+    def test_losing_position(self):
+        row = _parse_position(self._pos(realizedPnl=-10.0, totalBought=10.0))
+        assert row["result"] == "loss"
+        assert row["profit"] == -10.0
+        assert row["wager"] == 10.0
+        assert row["payout"] == 0.0
+
+    def test_breakeven_position(self):
+        row = _parse_position(self._pos(realizedPnl=0.0, totalBought=5.0))
+        assert row["result"] == "push"
+        assert row["profit"] == 0.0
+
+    def test_platform_is_polymarket(self):
+        row = _parse_position(self._pos())
+        assert row["platform"] == "Polymarket"
+
+    def test_epoch_timestamp_parsed(self):
+        row = _parse_position(self._pos(timestamp=1744300800))
+        assert row["date"] == "2025-04-10"
+
+    def test_epoch_string_timestamp_parsed(self):
+        row = _parse_position(self._pos(timestamp="1744300800"))
+        assert row["date"] == "2025-04-10"
+
+    def test_iso_timestamp_parsed(self):
+        row = _parse_position(self._pos(timestamp="2025-04-10T16:00:00Z"))
+        assert row["date"] == "2025-04-10"
+
+    def test_missing_timestamp_gives_empty_date(self):
+        row = _parse_position(self._pos(timestamp=None, created_at=None, date=None))
+        assert row["date"] == ""
+
+    def test_bet_type_game_from_title(self):
+        row = _parse_position(self._pos(title="Yankees vs Red Sox"))
+        assert row["bet_type"] == "game"
+
+    def test_bet_type_spread_from_title(self):
+        row = _parse_position(self._pos(title="Spread: Red Sox (-1.5)"))
+        assert row["bet_type"] == "spread"
+
+    def test_bet_type_total_from_title(self):
+        row = _parse_position(self._pos(title="Yankees vs Red Sox: O/U 8.5"))
+        assert row["bet_type"] == "total"
+
+    def test_bet_id_includes_outcome_and_asset(self):
+        row = _parse_position(self._pos(
+            conditionId="0xabc",
+            outcome="YES",
+            asset="98765432109876543210",
+        ))
+        assert row["bet_id"] == "poly_0xabc_YES_76543210"
+
+    def test_bet_id_without_asset(self):
+        row = _parse_position(self._pos(
+            conditionId="0xdef",
+            outcome="NO",
+            asset="",
+        ))
+        assert row["bet_id"] == "poly_0xdef_NO"
+
+    def test_distinct_bet_ids_for_both_sides(self):
+        yes_row = _parse_position(self._pos(
+            conditionId="0xabc", outcome="YES", asset="111111111122222222"
+        ))
+        no_row = _parse_position(self._pos(
+            conditionId="0xabc", outcome="NO", asset="333333333344444444"
+        ))
+        assert yes_row["bet_id"] != no_row["bet_id"]
+
+    def test_missing_pnl_fields_default_to_zero(self):
+        row = _parse_position(self._pos(realizedPnl=None, totalBought=None))
+        assert row["profit"] == 0.0
+        assert row["wager"] == 0.0
+
+    def test_string_numeric_fields_parsed(self):
+        row = _parse_position(self._pos(realizedPnl="3.25", totalBought="8.00"))
+        assert row["profit"] == 3.25
+        assert row["wager"] == 8.0
+
+
+class TestExistingBetIds:
+    """Test dedup ID loading from CSV."""
+
+    def test_reads_bet_ids_from_csv(self, tmp_path):
+        csv_path = tmp_path / "history.csv"
+        csv_path.write_text(
+            "date,platform,game,bet_type,line,odds,wager,result,payout,profit,bet_id,league\n"
+            "2025-04-10,Polymarket,Test,game,Test YES,n/a,10,win,15,5,poly_abc_YES,mlb\n"
+            "2025-04-10,Kalshi,Other,spread,Other -1.5,n/a,5,loss,0,-5,kalshi_xyz,mlb\n"
+        )
+        import settle_polymarket
+        orig = settle_polymarket.BETTING_HISTORY
+        settle_polymarket.BETTING_HISTORY = str(csv_path)
+        try:
+            ids = _existing_bet_ids()
+            assert "poly_abc_YES" in ids
+            assert "kalshi_xyz" in ids
+        finally:
+            settle_polymarket.BETTING_HISTORY = orig
+
+    def test_empty_when_no_file(self, tmp_path):
+        import settle_polymarket
+        orig = settle_polymarket.BETTING_HISTORY
+        settle_polymarket.BETTING_HISTORY = str(tmp_path / "nonexistent.csv")
+        try:
+            assert _existing_bet_ids() == set()
+        finally:
+            settle_polymarket.BETTING_HISTORY = orig
+
+
+class TestSettleToCsv:
+    """Integration tests for the full settlement flow."""
+
+    def test_skips_without_proxy(self, monkeypatch):
+        monkeypatch.delenv("POLYMARKET_PROXY", raising=False)
+        monkeypatch.delenv("POLYMARKET_WALLET_ADDRESS", raising=False)
+        result = settle_to_csv(wallet_address="0xtest")
+        assert result["settled"] == 0
+
+    def test_skips_without_wallet(self, monkeypatch):
+        monkeypatch.setenv("POLYMARKET_PROXY", "socks5h://127.0.0.1:8080")
+        monkeypatch.delenv("POLYMARKET_WALLET_ADDRESS", raising=False)
+        result = settle_to_csv()
+        assert result["settled"] == 0
+
+    def test_writes_new_positions_to_csv(self, monkeypatch, tmp_path):
+        csv_path = tmp_path / "history.csv"
+
+        import settle_polymarket
+        orig_hist = settle_polymarket.BETTING_HISTORY
+        orig_sync = settle_polymarket.SYNC_STATE_FILE
+        settle_polymarket.BETTING_HISTORY = str(csv_path)
+        settle_polymarket.SYNC_STATE_FILE = str(tmp_path / ".sync.json")
+
+        monkeypatch.setenv("POLYMARKET_PROXY", "socks5h://127.0.0.1:8080")
+
+        fake_positions = [
+            {
+                "conditionId": "0xabc",
+                "asset": "1111111122222222",
+                "title": "Yankees vs Red Sox",
+                "outcome": "YES",
+                "totalBought": 10.0,
+                "realizedPnl": 5.0,
+                "timestamp": 1744300800,
+                "side": "YES",
+            },
+        ]
+        monkeypatch.setattr(
+            "settle_polymarket.PolymarketClient.get_closed_positions",
+            lambda self, addr: fake_positions,
+        )
+
+        try:
+            result = settle_to_csv(wallet_address="0xtest")
+            assert result["settled"] == 1
+            assert result["skipped"] == 0
+
+            with open(csv_path) as f:
+                rows = list(csv.DictReader(f))
+            assert len(rows) == 1
+            assert rows[0]["platform"] == "Polymarket"
+            assert rows[0]["profit"] == "5.0"
+            assert rows[0]["result"] == "win"
+        finally:
+            settle_polymarket.BETTING_HISTORY = orig_hist
+            settle_polymarket.SYNC_STATE_FILE = orig_sync
+
+    def test_skips_already_recorded_positions(self, monkeypatch, tmp_path):
+        csv_path = tmp_path / "history.csv"
+        csv_path.write_text(
+            "date,platform,game,bet_type,line,odds,wager,result,payout,profit,bet_id,league\n"
+            "2025-04-10,Polymarket,Yankees vs Red Sox,game,Yankees vs Red Sox YES,n/a,10.0,win,15.0,5.0,poly_0xabc_YES_22222222,mlb\n"
+        )
+
+        import settle_polymarket
+        orig_hist = settle_polymarket.BETTING_HISTORY
+        orig_sync = settle_polymarket.SYNC_STATE_FILE
+        settle_polymarket.BETTING_HISTORY = str(csv_path)
+        settle_polymarket.SYNC_STATE_FILE = str(tmp_path / ".sync.json")
+
+        monkeypatch.setenv("POLYMARKET_PROXY", "socks5h://127.0.0.1:8080")
+
+        fake_positions = [
+            {
+                "conditionId": "0xabc",
+                "asset": "1111111122222222",
+                "title": "Yankees vs Red Sox",
+                "outcome": "YES",
+                "totalBought": 10.0,
+                "realizedPnl": 5.0,
+                "timestamp": 1744300800,
+                "side": "YES",
+            },
+        ]
+        monkeypatch.setattr(
+            "settle_polymarket.PolymarketClient.get_closed_positions",
+            lambda self, addr: fake_positions,
+        )
+
+        try:
+            result = settle_to_csv(wallet_address="0xtest")
+            assert result["settled"] == 0
+            assert result["skipped"] == 1
+        finally:
+            settle_polymarket.BETTING_HISTORY = orig_hist
+            settle_polymarket.SYNC_STATE_FILE = orig_sync

--- a/uv.lock
+++ b/uv.lock
@@ -160,7 +160,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "python-telegram-bot", extra = ["job-queue"] },
     { name = "pytz" },
-    { name = "requests" },
+    { name = "requests", extra = ["socks"] },
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -195,7 +195,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "python-telegram-bot", extras = ["job-queue"], specifier = ">=21.0" },
     { name = "pytz" },
-    { name = "requests" },
+    { name = "requests", extras = ["socks"] },
     { name = "scikit-learn" },
     { name = "scipy", specifier = ">=1.10" },
     { name = "streamlit" },
@@ -1277,6 +1277,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pysocks"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429, upload-time = "2019-09-20T02:07:35.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725, upload-time = "2019-09-20T02:06:22.938Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1369,6 +1378,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[package.optional-dependencies]
+socks = [
+    { name = "pysocks" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -174,6 +174,11 @@ test = [
     { name = "pytest" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "altair" },
@@ -197,6 +202,9 @@ requires-dist = [
     { name = "streamlit-autorefresh", specifier = ">=1.0.1" },
 ]
 provides-extras = ["test"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.0.2" }]
 
 [[package]]
 name = "certifi"


### PR DESCRIPTION
## Summary

- Adds Polymarket integration alongside Kalshi for CBB and MLB per-game markets (moneyline, spread, total)
- Uses Gamma REST API with SOCKS5 proxy (Jakarta Linode) for geo-restricted access -- no CLI dependency
- 3% sports taker fee model (vs Kalshi 7%), same `rate * P * (1-P)` formula
- Polymarket data displayed as purple-accented rows in dashboard bet cards with `Buy YES/NO @ price` action text
- Telegram `/settle` now settles Polymarket positions as step 3 after FanDuel and Kalshi
- All network fetches parallelized (ESPN + Kalshi + Polymarket via ThreadPoolExecutor)

Also fixes:
- Doubleheader resolution: `game_time` param added to Polymarket mapper, `grade_predictions.py` keying fixed for same-matchup collisions
- Timezone normalization: ESPN UTC times converted to Eastern before comparing with prediction display times
- NaN ticker crash in MLB game bet rendering
- Offset-aware date parsing (`-05:00` style offsets)

## Test plan

- [x] 617 tests pass (66 new covering client, mapper, fees, doubleheader keying)
- [x] Live verified: geoblock bypassed via Jakarta proxy, MLB game markets fetched with prices
- [x] Dashboard renders Polymarket rows in bet cards
- [ ] Run full CBB + MLB prediction pipeline with proxy active
- [ ] Place a test bet on Polymarket and verify `/settle` picks it up

Generated with [Claude Code](https://claude.com/claude-code)