### PR TITLE
Prepare MLB market-odds anchor v2

### DIFF
--- a/mlb_research/anchor/anchor_eval.py
+++ b/mlb_research/anchor/anchor_eval.py
@@ -65,8 +65,15 @@ from sklearn.metrics import brier_score_loss, log_loss
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 ANCHOR_DIR = os.path.dirname(os.path.abspath(__file__))
-FROZEN_CSV = os.path.join(ANCHOR_DIR, "mlb_frozen.csv")
-MANIFEST_PATH = os.path.join(ANCHOR_DIR, "anchor_manifest.json")
+FROZEN_CSV = os.environ.get("MLB_RESEARCH_FROZEN_CSV") or os.path.join(
+    ANCHOR_DIR, "mlb_frozen.csv"
+)
+MANIFEST_PATH = os.environ.get("MLB_RESEARCH_ANCHOR_MANIFEST") or os.path.join(
+    ANCHOR_DIR, "anchor_manifest.json"
+)
+
+sys.path.insert(0, REPO_ROOT)
+from mlb_research.market_odds import american_odds_profit  # noqa: E402
 
 
 # Frozen copy of production TimeAwareCalibratedGBM as of commit b89f491
@@ -489,6 +496,7 @@ def load_frozen_df() -> pd.DataFrame:
 SUPPORTED_MODEL_FAMILIES = {"sklearn_gbm", "lightgbm", "xgboost"}
 SUPPORTED_CALIBRATION_METHODS = {"sigmoid", "isotonic"}
 SUPPORTED_TARGETS = {"home_win", "margin"}
+SUPPORTED_ROI_MODES = {"flat_110", "moneyline"}
 
 
 def calibration_method_is_active(config: dict) -> bool:
@@ -711,6 +719,18 @@ def walk_forward_window(
         else:
             est.fit(train[features].astype(float), train[target].astype(int))
         probs = est.predict_proba(week[features].astype(float))[:, 1]
+        home_moneyline = (
+            week["team_moneyline"]
+            if "team_moneyline" in week.columns
+            else week["moneyline"]
+            if "moneyline" in week.columns
+            else pd.Series(np.nan, index=week.index)
+        )
+        away_moneyline = (
+            week["opp_moneyline"]
+            if "opp_moneyline" in week.columns
+            else pd.Series(np.nan, index=week.index)
+        )
 
         # Surface per-fold fallback usage so the metrics JSON makes silent
         # path-fallback observable. The new TimeAwareCalibrated wrapper
@@ -737,6 +757,8 @@ def walk_forward_window(
                     "prob_home": probs,
                     "target": week[EVAL_TARGET].astype(int).values,
                     "conf": np.maximum(probs, 1 - probs),
+                    "home_moneyline": home_moneyline.values,
+                    "away_moneyline": away_moneyline.values,
                 }
             )
         )
@@ -757,7 +779,38 @@ def walk_forward_window(
     return pd.concat(fold_logs, ignore_index=True), diagnostics
 
 
-def summarize(predictions: pd.DataFrame | None, high_conf_threshold: float) -> dict:
+def _moneyline_roi_units(
+    predictions: pd.DataFrame,
+    hc_mask: pd.Series,
+    pred_class: np.ndarray,
+    y: np.ndarray,
+) -> tuple[float | None, int, int]:
+    """Score high-confidence picks at the selected side's actual moneyline."""
+    roi = 0.0
+    priced = 0
+    missing = 0
+    for pos, is_hc in enumerate(hc_mask.to_numpy()):
+        if not is_hc:
+            continue
+        selected_odds = (
+            predictions.iloc[pos]["home_moneyline"]
+            if pred_class[pos] == 1
+            else predictions.iloc[pos]["away_moneyline"]
+        )
+        profit = american_odds_profit(selected_odds)
+        if not np.isfinite(profit):
+            missing += 1
+            continue
+        priced += 1
+        roi += profit if pred_class[pos] == y[pos] else -1.0
+    return (float(roi) if priced else None), priced, missing
+
+
+def summarize(
+    predictions: pd.DataFrame | None,
+    high_conf_threshold: float,
+    roi_mode: str = "flat_110",
+) -> dict:
     if predictions is None or predictions.empty:
         return {
             "brier": None,
@@ -765,6 +818,9 @@ def summarize(predictions: pd.DataFrame | None, high_conf_threshold: float) -> d
             "accuracy": None,
             "high_conf_accuracy": None,
             "roi_units": None,
+            "roi_mode": roi_mode,
+            "n_roi_priced": 0,
+            "n_roi_missing_price": 0,
             "n_games": 0,
             "n_high_conf": 0,
         }
@@ -783,14 +839,23 @@ def summarize(predictions: pd.DataFrame | None, high_conf_threshold: float) -> d
     if n_hc:
         hc_correct = int((pred_class[hc_mask.values] == y[hc_mask.values]).sum())
         hc_acc = hc_correct / n_hc
-        payout = 100.0 / 110.0  # -110 break-even payout
-        roi = float((hc_correct * payout) - (n_hc - hc_correct))
+        if roi_mode == "moneyline":
+            roi, n_roi_priced, n_roi_missing = _moneyline_roi_units(
+                predictions, hc_mask, pred_class, y
+            )
+        else:
+            payout = 100.0 / 110.0  # -110 break-even payout
+            roi = float((hc_correct * payout) - (n_hc - hc_correct))
+            n_roi_priced = n_hc
+            n_roi_missing = 0
     else:
         # Zero high-conf picks: ROI is undefined, not zero. A `0.0` here would
         # be indistinguishable from a break-even 54-pick slate and would fool
         # the keep/revert rule.
         hc_acc = None
         roi = None
+        n_roi_priced = 0
+        n_roi_missing = 0
 
     return {
         "brier": brier,
@@ -798,6 +863,9 @@ def summarize(predictions: pd.DataFrame | None, high_conf_threshold: float) -> d
         "accuracy": acc,
         "high_conf_accuracy": hc_acc,
         "roi_units": roi,
+        "roi_mode": roi_mode,
+        "n_roi_priced": n_roi_priced,
+        "n_roi_missing_price": n_roi_missing,
         "n_games": int(len(predictions)),
         "n_high_conf": n_hc,
     }
@@ -827,6 +895,7 @@ VALID_TOP_LEVEL_CONFIG_KEYS = {
     "calibrated",
     "calibration_method",
     "target",
+    "roi_mode",
 }
 
 VALID_HYPERPARAM_KEYS = {
@@ -1023,6 +1092,12 @@ def main():
 
     features = config.get("features") or DEFAULT_MLB_FEATURES
     target = config.get("target", "home_win")
+    roi_mode = config.get("roi_mode", "flat_110")
+    if roi_mode not in SUPPORTED_ROI_MODES:
+        sys.exit(
+            f"Unsupported roi_mode={roi_mode!r}. Must be one of "
+            f"{sorted(SUPPORTED_ROI_MODES)}."
+        )
 
     manifest = load_manifest()
     df = load_frozen_df()
@@ -1033,7 +1108,7 @@ def main():
     for key in ("optimizer", "monitor_2025_tail", "monitor_2026"):
         start, end_exclusive = parse_window_bounds(manifest, key)
         preds, diag = walk_forward_window(df, features, target, start, end_exclusive, factory)
-        results[key] = summarize(preds, HIGH_CONF_THRESHOLD)
+        results[key] = summarize(preds, HIGH_CONF_THRESHOLD, roi_mode=roi_mode)
         diagnostics_by_window[key] = diag
 
     results["_meta"] = {
@@ -1050,6 +1125,7 @@ def main():
             else None
         ),
         "target": target,
+        "roi_mode": roi_mode,
         "high_conf_threshold": HIGH_CONF_THRESHOLD,
         "anchor_sha256": manifest["sha256"],
         # Emit family-aware effective hyperparameters: framework defaults

--- a/mlb_research/anchor_v2/README.md
+++ b/mlb_research/anchor_v2/README.md
@@ -43,3 +43,33 @@ snapshot time is acceptable if it is consistent and documented.
 The builder is intentionally vendor-neutral. It expects those odds to land in
 `data/mlb_training_data_processed.csv` as paired `moneyline` values before
 freezing a market anchor.
+
+## ESPN Core Odds Backfill
+
+The regular ESPN scoreboard endpoint is not sufficient for completed games:
+historical scoreboard responses often omit the `odds` block. ESPN's core
+competition odds endpoint does retain historical provider odds by event ID.
+
+Use the backfill helper to discover event IDs from the scoreboard and fetch the
+core odds endpoint:
+
+```bash
+uv run python mlb_research/anchor_v2/backfill_espn_odds.py \
+  --start-date 2025-04-01 \
+  --end-date 2026-04-02 \
+  --basis-order close \
+  --odds-output data/mlb_espn_odds_backfill.csv \
+  --enriched-output /tmp/mlb_training_data_with_espn_odds.csv
+```
+
+Observed sample behavior on May 1, 2026:
+
+- `2025-04-15`: 15/15 games had ESPN BET closing moneylines.
+- `2025-07-01`: 14/15 games had closing moneylines.
+- `2026-04-01`: 15/15 games had DraftKings closing moneylines.
+- `2026-05-01`: 15/15 games had current DraftKings moneylines, but no closing
+  moneylines yet because games had not completed.
+
+For final research, prefer a completed historical window and `close` prices.
+For same-day/live production, use `current` prices from the prediction-time
+snapshot rather than closing prices.

--- a/mlb_research/anchor_v2/README.md
+++ b/mlb_research/anchor_v2/README.md
@@ -1,0 +1,45 @@
+# MLB Market Anchor V2
+
+Track 2 is blocked on source data, not model code. The current
+`data/mlb_training_data_processed.csv` has the `moneyline`, `run_line`, and
+`total_line` columns, but moneyline coverage is 0%, so the existing frozen
+anchor cannot answer market-aware research questions.
+
+Use the diagnostic command before freezing any market-aware anchor:
+
+```bash
+uv run python mlb_research/anchor_v2/build_market_anchor.py --diagnose-only
+```
+
+The freeze command intentionally fails unless paired moneyline coverage clears
+the configured threshold:
+
+```bash
+uv run python mlb_research/anchor_v2/build_market_anchor.py --min-coverage 0.95
+```
+
+When historical odds are backfilled, this builder adds:
+
+- `team_moneyline`
+- `opp_moneyline`
+- `market_team_implied_prob`
+- `market_opp_implied_prob`
+- `market_overround`
+- `market_team_no_vig_prob`
+- `market_home_no_vig_prob`
+
+The next real research run should use `market_home_no_vig_prob` as a feature
+and `roi_mode="moneyline"` in configs so ROI is scored at actual prices rather
+than flat -110.
+
+## Odds Source Requirement
+
+Yes, Track 2 needs an odds source before it can produce model conclusions.
+The minimum acceptable source is historical game-level MLB moneylines for both
+sides of each game, keyed closely enough to join on date, teams, and preferably
+game time for doubleheaders. Closing lines are preferred; a fixed pre-game
+snapshot time is acceptable if it is consistent and documented.
+
+The builder is intentionally vendor-neutral. It expects those odds to land in
+`data/mlb_training_data_processed.csv` as paired `moneyline` values before
+freezing a market anchor.

--- a/mlb_research/anchor_v2/backfill_espn_odds.py
+++ b/mlb_research/anchor_v2/backfill_espn_odds.py
@@ -1,0 +1,393 @@
+"""Backfill MLB moneylines from ESPN's core odds endpoint.
+
+The normal ESPN scoreboard endpoint drops odds for many completed games. The
+core competition odds endpoint retains provider odds for historical events:
+
+    https://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/{event_id}/competitions/{competition_id}/odds
+
+This script discovers ESPN event IDs from the scoreboard by date, fetches the
+core odds for each event, and can emit:
+
+1. A game-level odds CSV.
+2. An enriched copy of the MLB training CSV with row-wise ``moneyline`` filled.
+
+It does not modify the source CSV unless an explicit output path is supplied.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import requests
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SOURCE = REPO_ROOT / "data" / "mlb_training_data_processed.csv"
+DEFAULT_ODDS_OUTPUT = REPO_ROOT / "data" / "mlb_espn_odds_backfill.csv"
+DEFAULT_CACHE_DIR = REPO_ROOT / ".cache" / "espn_mlb_odds"
+
+SCOREBOARD_URL = (
+    "https://site.api.espn.com/apis/site/v2/sports/baseball/mlb/"
+    "scoreboard?limit=200&dates={date_yyyymmdd}"
+)
+CORE_ODDS_URL = (
+    "https://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/"
+    "events/{event_id}/competitions/{competition_id}/odds?lang=en&region=us"
+)
+
+
+@dataclass(frozen=True)
+class EspnEvent:
+    date: str
+    game_time: str
+    event_id: str
+    competition_id: str
+    home_abbr: str
+    away_abbr: str
+    home_team: str
+    away_team: str
+
+
+def _cache_path(cache_dir: Path, namespace: str, key: str) -> Path:
+    return cache_dir / namespace / f"{key}.json"
+
+
+def _get_json(
+    session: requests.Session,
+    url: str,
+    cache_path: Path | None,
+    sleep_seconds: float,
+) -> dict:
+    if cache_path and cache_path.exists():
+        return json.loads(cache_path.read_text())
+    response = session.get(url, timeout=20)
+    response.raise_for_status()
+    data = response.json()
+    if cache_path:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(json.dumps(data))
+    if sleep_seconds > 0:
+        time.sleep(sleep_seconds)
+    return data
+
+
+def _american_from_value(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        for key in ("american", "alternateDisplayValue", "displayValue"):
+            raw = value.get(key)
+            if raw not in (None, "", "EVEN"):
+                return _american_from_value(raw)
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        text = str(value).strip()
+        return text or None
+    if not math.isfinite(number) or number == 0:
+        return None
+    return float(number)
+
+
+def _float_from_value(value: Any) -> float:
+    if value is None:
+        return float("nan")
+    if isinstance(value, dict):
+        for key in ("value", "line", "american", "alternateDisplayValue"):
+            parsed = _float_from_value(value.get(key))
+            if math.isfinite(parsed):
+                return parsed
+        return float("nan")
+    text = str(value).strip().lower().replace("+", "")
+    if not text:
+        return float("nan")
+    if text.startswith(("o", "u")):
+        text = text[1:]
+    try:
+        return float(text)
+    except ValueError:
+        return float("nan")
+
+
+def _extract_moneyline(team_odds: dict, basis_order: list[str]) -> tuple[float | None, str | None]:
+    for basis in basis_order:
+        moneyline = (team_odds.get(basis) or {}).get("moneyLine")
+        american = _american_from_value(moneyline)
+        if american is not None:
+            return american, basis
+    american = _american_from_value(team_odds.get("moneyLine"))
+    if american is not None:
+        return american, "top_level"
+    return None, None
+
+
+def _extract_spread_line(team_odds: dict, basis: str | None) -> float:
+    if not basis:
+        return float("nan")
+    return _float_from_value((team_odds.get(basis) or {}).get("pointSpread"))
+
+
+def _provider_matches(item: dict, provider: str | None) -> bool:
+    if not provider:
+        return True
+    wanted = provider.strip().lower()
+    got = str((item.get("provider") or {}).get("name", "")).strip().lower()
+    return got == wanted
+
+
+def _select_odds_item(
+    items: list[dict],
+    provider: str | None,
+    basis_order: list[str],
+) -> tuple[dict | None, str | None, str | None, str | None, str | None]:
+    for item in items:
+        if not _provider_matches(item, provider):
+            continue
+        home_odds = item.get("homeTeamOdds") or {}
+        away_odds = item.get("awayTeamOdds") or {}
+        home_ml, home_basis = _extract_moneyline(home_odds, basis_order)
+        away_ml, away_basis = _extract_moneyline(away_odds, basis_order)
+        if home_ml is not None and away_ml is not None:
+            return item, home_ml, away_ml, home_basis, away_basis
+    return None, None, None, None, None
+
+
+def fetch_scoreboard_events(
+    session: requests.Session,
+    date: pd.Timestamp,
+    cache_dir: Path | None,
+    sleep_seconds: float,
+) -> list[EspnEvent]:
+    date_yyyymmdd = date.strftime("%Y%m%d")
+    cache_path = _cache_path(cache_dir, "scoreboard", date_yyyymmdd) if cache_dir else None
+    data = _get_json(
+        session,
+        SCOREBOARD_URL.format(date_yyyymmdd=date_yyyymmdd),
+        cache_path,
+        sleep_seconds,
+    )
+    events = []
+    for event in data.get("events", []):
+        comp = (event.get("competitions") or [{}])[0]
+        home = away = None
+        for competitor in comp.get("competitors", []):
+            if competitor.get("homeAway") == "home":
+                home = competitor
+            elif competitor.get("homeAway") == "away":
+                away = competitor
+        if not home or not away:
+            continue
+        event_dt = pd.to_datetime(event.get("date", ""), utc=True, errors="coerce")
+        game_time = event_dt.strftime("%H:%M") if pd.notna(event_dt) else ""
+        events.append(
+            EspnEvent(
+                date=date.strftime("%Y-%m-%d"),
+                game_time=game_time,
+                event_id=str(event.get("id", "")),
+                competition_id=str(comp.get("id") or event.get("id", "")),
+                home_abbr=str(home.get("team", {}).get("abbreviation", "")),
+                away_abbr=str(away.get("team", {}).get("abbreviation", "")),
+                home_team=str(home.get("team", {}).get("displayName", "")),
+                away_team=str(away.get("team", {}).get("displayName", "")),
+            )
+        )
+    return events
+
+
+def fetch_event_odds(
+    session: requests.Session,
+    event: EspnEvent,
+    cache_dir: Path | None,
+    sleep_seconds: float,
+    provider: str | None,
+    basis_order: list[str],
+) -> dict:
+    cache_path = _cache_path(cache_dir, "odds", event.event_id) if cache_dir else None
+    data = _get_json(
+        session,
+        CORE_ODDS_URL.format(event_id=event.event_id, competition_id=event.competition_id),
+        cache_path,
+        sleep_seconds,
+    )
+    items = data.get("items", [])
+    item, home_ml, away_ml, home_basis, away_basis = _select_odds_item(
+        items, provider, basis_order
+    )
+    provider_info = (item or {}).get("provider") or {}
+    home_odds = (item or {}).get("homeTeamOdds") or {}
+    away_odds = (item or {}).get("awayTeamOdds") or {}
+    return {
+        "date": event.date,
+        "game_time": event.game_time,
+        "event_id": event.event_id,
+        "competition_id": event.competition_id,
+        "provider_id": provider_info.get("id", ""),
+        "provider_name": provider_info.get("name", ""),
+        "home_team": event.home_team,
+        "away_team": event.away_team,
+        "home_abbr": event.home_abbr,
+        "away_abbr": event.away_abbr,
+        "home_moneyline": home_ml,
+        "away_moneyline": away_ml,
+        "home_price_basis": home_basis,
+        "away_price_basis": away_basis,
+        "home_run_line": _extract_spread_line(home_odds, home_basis),
+        "away_run_line": _extract_spread_line(away_odds, away_basis),
+        "total_line": _float_from_value((item or {}).get("overUnder")),
+        "over_odds": _american_from_value((item or {}).get("overOdds")),
+        "under_odds": _american_from_value((item or {}).get("underOdds")),
+        "odds_items_count": len(items),
+    }
+
+
+def collect_espn_odds(
+    source_df: pd.DataFrame,
+    start_date: str | None,
+    end_date: str | None,
+    provider: str | None,
+    basis_order: list[str],
+    cache_dir: Path | None,
+    sleep_seconds: float,
+) -> pd.DataFrame:
+    dates = pd.to_datetime(source_df["date"], errors="coerce").dropna()
+    if start_date:
+        dates = dates[dates >= pd.Timestamp(start_date)]
+    if end_date:
+        dates = dates[dates <= pd.Timestamp(end_date)]
+    unique_dates = sorted(dates.dt.normalize().unique())
+
+    rows = []
+    with requests.Session() as session:
+        for date in unique_dates:
+            events = fetch_scoreboard_events(session, pd.Timestamp(date), cache_dir, sleep_seconds)
+            for event in events:
+                rows.append(
+                    fetch_event_odds(
+                        session,
+                        event,
+                        cache_dir,
+                        sleep_seconds,
+                        provider,
+                        basis_order,
+                    )
+                )
+    return pd.DataFrame(rows)
+
+
+def enrich_training_rows(source_df: pd.DataFrame, odds_df: pd.DataFrame) -> pd.DataFrame:
+    out = source_df.copy()
+    required = {"date", "game_time", "team_abbr", "opp_abbr", "moneyline", "run_line", "total_line"}
+    missing = sorted(required - set(out.columns))
+    if missing:
+        raise ValueError(f"Source CSV missing required columns: {missing}")
+
+    home_map = {}
+    away_map = {}
+    for row in odds_df.to_dict("records"):
+        home_key = (row["date"], row["game_time"], row["home_abbr"], row["away_abbr"])
+        away_key = (row["date"], row["game_time"], row["away_abbr"], row["home_abbr"])
+        home_map[home_key] = row
+        away_map[away_key] = row
+
+    for idx, row in out.iterrows():
+        key = (
+            str(row["date"]),
+            str(row.get("game_time", "")),
+            str(row.get("team_abbr", "")),
+            str(row.get("opp_abbr", "")),
+        )
+        if key in home_map:
+            odds = home_map[key]
+            out.at[idx, "moneyline"] = odds["home_moneyline"]
+            out.at[idx, "run_line"] = odds["home_run_line"]
+            out.at[idx, "total_line"] = odds["total_line"]
+        elif key in away_map:
+            odds = away_map[key]
+            out.at[idx, "moneyline"] = odds["away_moneyline"]
+            out.at[idx, "run_line"] = odds["away_run_line"]
+            out.at[idx, "total_line"] = odds["total_line"]
+    return out
+
+
+def _coverage_report(odds_df: pd.DataFrame, enriched: pd.DataFrame | None = None) -> dict:
+    games = int(len(odds_df))
+    complete_ml = odds_df["home_moneyline"].notna() & odds_df["away_moneyline"].notna()
+    report = {
+        "games": games,
+        "complete_moneyline_games": int(complete_ml.sum()),
+        "complete_moneyline_game_share": float(complete_ml.mean()) if games else 0.0,
+    }
+    if enriched is not None:
+        moneyline = pd.to_numeric(enriched["moneyline"], errors="coerce")
+        report.update(
+            {
+                "source_rows": int(len(enriched)),
+                "enriched_moneyline_rows": int(moneyline.notna().sum()),
+                "enriched_moneyline_row_share": float(moneyline.notna().mean())
+                if len(enriched)
+                else 0.0,
+            }
+        )
+    return report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, default=DEFAULT_SOURCE)
+    parser.add_argument("--odds-output", type=Path, default=DEFAULT_ODDS_OUTPUT)
+    parser.add_argument("--enriched-output", type=Path)
+    parser.add_argument("--start-date")
+    parser.add_argument("--end-date")
+    parser.add_argument("--provider", help="Optional provider name filter, e.g. 'ESPN BET'.")
+    parser.add_argument(
+        "--basis-order",
+        default="close",
+        help="Comma-separated price basis preference.",
+    )
+    parser.add_argument("--cache-dir", type=Path, default=DEFAULT_CACHE_DIR)
+    parser.add_argument("--no-cache", action="store_true")
+    parser.add_argument("--sleep", type=float, default=0.05)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    if not args.source.exists():
+        sys.exit(f"Source CSV not found: {args.source}")
+
+    source_df = pd.read_csv(args.source, low_memory=False)
+    basis_order = [part.strip() for part in args.basis_order.split(",") if part.strip()]
+    cache_dir = None if args.no_cache else args.cache_dir
+    odds_df = collect_espn_odds(
+        source_df=source_df,
+        start_date=args.start_date,
+        end_date=args.end_date,
+        provider=args.provider,
+        basis_order=basis_order,
+        cache_dir=cache_dir,
+        sleep_seconds=args.sleep,
+    )
+    enriched = enrich_training_rows(source_df, odds_df)
+    print(json.dumps(_coverage_report(odds_df, enriched), indent=2))
+
+    if args.dry_run:
+        return
+
+    args.odds_output.parent.mkdir(parents=True, exist_ok=True)
+    odds_df.to_csv(args.odds_output, index=False)
+    print(f"Wrote odds backfill: {args.odds_output}")
+    if args.enriched_output:
+        args.enriched_output.parent.mkdir(parents=True, exist_ok=True)
+        enriched.to_csv(args.enriched_output, index=False)
+        print(f"Wrote enriched source CSV: {args.enriched_output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/mlb_research/anchor_v2/backfill_espn_odds.py
+++ b/mlb_research/anchor_v2/backfill_espn_odds.py
@@ -120,13 +120,15 @@ def _float_from_value(value: Any) -> float:
 
 def _extract_moneyline(team_odds: dict, basis_order: list[str]) -> tuple[float | None, str | None]:
     for basis in basis_order:
+        if basis == "top_level":
+            american = _american_from_value(team_odds.get("moneyLine"))
+            if american is not None:
+                return american, "top_level"
+            continue
         moneyline = (team_odds.get(basis) or {}).get("moneyLine")
         american = _american_from_value(moneyline)
         if american is not None:
             return american, basis
-    american = _american_from_value(team_odds.get("moneyLine"))
-    if american is not None:
-        return american, "top_level"
     return None, None
 
 

--- a/mlb_research/anchor_v2/build_market_anchor.py
+++ b/mlb_research/anchor_v2/build_market_anchor.py
@@ -61,14 +61,21 @@ def _window_count(dates: pd.Series, start: str, end: str | None = None) -> int:
     return int(mask.sum())
 
 
+def _display_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
 def build_manifest(source: Path, output: Path, df: pd.DataFrame, coverage: dict) -> dict:
     dates = pd.to_datetime(df["date"], errors="coerce").dropna()
     date_min = dates.min().strftime("%Y-%m-%d") if not dates.empty else ""
     date_max = dates.max().strftime("%Y-%m-%d") if not dates.empty else ""
     return {
         "snapshot_timestamp_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "source_csv": str(source.relative_to(REPO_ROOT)),
-        "frozen_csv": str(output.relative_to(REPO_ROOT)),
+        "source_csv": _display_path(source),
+        "frozen_csv": _display_path(output),
         "row_count": int(len(df)),
         "column_count": int(len(df.columns)),
         "sha256": sha256_of_file(output) if output.exists() else None,

--- a/mlb_research/anchor_v2/build_market_anchor.py
+++ b/mlb_research/anchor_v2/build_market_anchor.py
@@ -1,0 +1,143 @@
+"""Build or diagnose a market-aware MLB research anchor.
+
+This is the Track 2 entry point. It deliberately refuses to freeze an anchor
+unless the source CSV has enough paired moneyline coverage to support
+market-implied features and moneyline ROI evaluation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import stat
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SOURCE = REPO_ROOT / "data" / "mlb_training_data_processed.csv"
+DEFAULT_OUTPUT = REPO_ROOT / "mlb_research" / "anchor_v2" / "mlb_market_frozen.csv"
+DEFAULT_MANIFEST = REPO_ROOT / "mlb_research" / "anchor_v2" / "market_anchor_manifest.json"
+
+sys.path.insert(0, str(REPO_ROOT))
+from mlb_research.market_odds import (  # noqa: E402
+    MARKET_FEATURE_COLUMNS,
+    add_market_odds_features,
+    market_coverage_summary,
+)
+
+OPTIMIZER_START = "2025-04-01"
+OPTIMIZER_END = "2025-07-31"
+MONITOR_2025_TAIL_START = "2025-08-01"
+MONITOR_2025_TAIL_END = "2025-10-31"
+MONITOR_2026_START = "2026-03-25"
+
+
+def sha256_of_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def make_read_only(path: Path) -> None:
+    os.chmod(path, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+
+
+def restore_writable(path: Path) -> None:
+    if path.exists():
+        os.chmod(path, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
+
+
+def _window_count(dates: pd.Series, start: str, end: str | None = None) -> int:
+    mask = dates >= start
+    if end is not None:
+        mask &= dates <= end
+    return int(mask.sum())
+
+
+def build_manifest(source: Path, output: Path, df: pd.DataFrame, coverage: dict) -> dict:
+    dates = pd.to_datetime(df["date"], errors="coerce").dropna()
+    date_min = dates.min().strftime("%Y-%m-%d") if not dates.empty else ""
+    date_max = dates.max().strftime("%Y-%m-%d") if not dates.empty else ""
+    return {
+        "snapshot_timestamp_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "source_csv": str(source.relative_to(REPO_ROOT)),
+        "frozen_csv": str(output.relative_to(REPO_ROOT)),
+        "row_count": int(len(df)),
+        "column_count": int(len(df.columns)),
+        "sha256": sha256_of_file(output) if output.exists() else None,
+        "date_min": date_min,
+        "date_max": date_max,
+        "market_feature_columns": MARKET_FEATURE_COLUMNS,
+        "market_coverage": coverage,
+        "windows": {
+            "optimizer": {
+                "start": OPTIMIZER_START,
+                "end": OPTIMIZER_END,
+                "row_count": _window_count(dates, OPTIMIZER_START, OPTIMIZER_END),
+            },
+            "monitor_2025_tail": {
+                "start": MONITOR_2025_TAIL_START,
+                "end": MONITOR_2025_TAIL_END,
+                "row_count": _window_count(dates, MONITOR_2025_TAIL_START, MONITOR_2025_TAIL_END),
+            },
+            "monitor_2026": {
+                "start": MONITOR_2026_START,
+                "end": date_max,
+                "row_count": _window_count(dates, MONITOR_2026_START),
+            },
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, default=DEFAULT_SOURCE)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--min-coverage", type=float, default=0.95)
+    parser.add_argument("--diagnose-only", action="store_true")
+    parser.add_argument("--force", action="store_true")
+    args = parser.parse_args()
+
+    if not args.source.exists():
+        sys.exit(f"Source CSV not found: {args.source}")
+    if args.output.exists() and not args.force and not args.diagnose_only:
+        sys.exit(f"Output already exists: {args.output}. Pass --force to replace it.")
+
+    df = pd.read_csv(args.source, low_memory=False)
+    enriched = add_market_odds_features(df)
+    coverage = market_coverage_summary(df)
+    manifest = build_manifest(args.source.resolve(), args.output.resolve(), enriched, coverage)
+
+    if args.diagnose_only:
+        print(json.dumps(manifest, indent=2))
+        return
+
+    if coverage["complete_no_vig_share"] < args.min_coverage:
+        sys.exit(
+            "Refusing to freeze market anchor: paired moneyline coverage is "
+            f"{coverage['complete_no_vig_share']:.1%}, below required "
+            f"{args.min_coverage:.1%}. Run with --diagnose-only for details."
+        )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.manifest.parent.mkdir(parents=True, exist_ok=True)
+    restore_writable(args.output)
+    enriched.to_csv(args.output, index=False)
+    manifest["sha256"] = sha256_of_file(args.output)
+    args.manifest.write_text(json.dumps(manifest, indent=2) + "\n")
+    make_read_only(args.output)
+
+    print(f"Market anchor written to {args.output}")
+    print(f"Manifest written to {args.manifest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/mlb_research/market_odds.py
+++ b/mlb_research/market_odds.py
@@ -1,0 +1,173 @@
+"""Market-odds helpers for MLB research anchors.
+
+The production prediction path already reads same-day market prices, but the
+frozen research anchor has historically carried empty moneyline columns. This
+module is the shared, deterministic piece needed before a market-aware anchor
+can be frozen: parse American odds, pair home/away rows, remove sportsbook vig,
+and expose per-row market probabilities as normal tabular features.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+
+MARKET_FEATURE_COLUMNS = [
+    "team_moneyline",
+    "opp_moneyline",
+    "market_team_implied_prob",
+    "market_opp_implied_prob",
+    "market_overround",
+    "market_team_no_vig_prob",
+    "market_home_no_vig_prob",
+]
+
+
+def american_odds_to_implied_prob(value: Any) -> float:
+    """Convert American odds to raw implied probability.
+
+    Returns NaN for empty, zero, or unparseable values so callers can use normal
+    pandas missing-value semantics.
+    """
+    if value is None:
+        return float("nan")
+    if isinstance(value, str):
+        cleaned = value.strip().upper()
+        if not cleaned:
+            return float("nan")
+        if cleaned == "EVEN":
+            cleaned = "100"
+        cleaned = cleaned.replace("+", "")
+    else:
+        cleaned = value
+    try:
+        odds = float(cleaned)
+    except (TypeError, ValueError):
+        return float("nan")
+    if not math.isfinite(odds) or odds == 0:
+        return float("nan")
+    if odds < 0:
+        return abs(odds) / (abs(odds) + 100.0)
+    return 100.0 / (odds + 100.0)
+
+
+def american_odds_profit(value: Any, stake: float = 1.0) -> float:
+    """Return profit on a winning American-odds bet for a given stake."""
+    if value is None:
+        return float("nan")
+    if isinstance(value, str):
+        cleaned = value.strip().upper()
+        if not cleaned:
+            return float("nan")
+        if cleaned == "EVEN":
+            cleaned = "100"
+        cleaned = cleaned.replace("+", "")
+    else:
+        cleaned = value
+    try:
+        odds = float(cleaned)
+    except (TypeError, ValueError):
+        return float("nan")
+    if not math.isfinite(odds) or odds == 0:
+        return float("nan")
+    if odds < 0:
+        return stake * 100.0 / abs(odds)
+    return stake * odds / 100.0
+
+
+def no_vig_probability(team_implied: Any, opponent_implied: Any) -> float:
+    """Normalize two raw implied probabilities to remove overround."""
+    try:
+        team = float(team_implied)
+        opponent = float(opponent_implied)
+    except (TypeError, ValueError):
+        return float("nan")
+    total = team + opponent
+    if not math.isfinite(team) or not math.isfinite(opponent) or total <= 0:
+        return float("nan")
+    return team / total
+
+
+def _game_keys(df: pd.DataFrame) -> pd.Series:
+    teams = df["team"].astype(str)
+    opponents = df["opponent"].astype(str)
+    low = np.where(teams <= opponents, teams, opponents)
+    high = np.where(teams <= opponents, opponents, teams)
+    game_time = df["game_time"].fillna("").astype(str) if "game_time" in df else ""
+    return (
+        df["date"].astype(str)
+        + "|"
+        + pd.Series(game_time, index=df.index).astype(str)
+        + "|"
+        + pd.Series(low, index=df.index).astype(str)
+        + "|"
+        + pd.Series(high, index=df.index).astype(str)
+    )
+
+
+def add_market_odds_features(df: pd.DataFrame) -> pd.DataFrame:
+    """Add paired moneyline and no-vig market probability columns.
+
+    Input rows must follow the MLB pipeline convention: two rows per game, one
+    per team, with the row's own American moneyline in ``moneyline``. Games are
+    paired by date, game_time, and unordered team/opponent names, which keeps
+    doubleheaders separated when game_time is present.
+    """
+    required = {"date", "team", "opponent", "is_home", "moneyline"}
+    missing = sorted(required - set(df.columns))
+    if missing:
+        raise ValueError(f"Missing required market-odds columns: {missing}")
+
+    out = df.copy()
+    out["team_moneyline"] = pd.to_numeric(out["moneyline"], errors="coerce")
+    out["opp_moneyline"] = np.nan
+    out["_market_game_key"] = _game_keys(out)
+
+    for _, idx in out.groupby("_market_game_key").groups.items():
+        idx = list(idx)
+        if len(idx) != 2:
+            continue
+        left, right = idx
+        out.at[left, "opp_moneyline"] = out.at[right, "team_moneyline"]
+        out.at[right, "opp_moneyline"] = out.at[left, "team_moneyline"]
+
+    out["market_team_implied_prob"] = out["team_moneyline"].map(american_odds_to_implied_prob)
+    out["market_opp_implied_prob"] = out["opp_moneyline"].map(american_odds_to_implied_prob)
+    out["market_overround"] = (
+        out["market_team_implied_prob"] + out["market_opp_implied_prob"] - 1.0
+    )
+    out["market_team_no_vig_prob"] = [
+        no_vig_probability(team, opp)
+        for team, opp in zip(out["market_team_implied_prob"], out["market_opp_implied_prob"])
+    ]
+    out["market_home_no_vig_prob"] = np.where(
+        out["is_home"].astype(int) == 1,
+        out["market_team_no_vig_prob"],
+        1.0 - out["market_team_no_vig_prob"],
+    )
+    out.loc[out["market_team_no_vig_prob"].isna(), "market_home_no_vig_prob"] = np.nan
+    return out.drop(columns=["_market_game_key"])
+
+
+def market_coverage_summary(df: pd.DataFrame) -> dict:
+    """Return row-level coverage counts for market-derived columns."""
+    enriched = add_market_odds_features(df)
+    rows = int(len(enriched))
+    complete_market = enriched["market_team_no_vig_prob"].notna()
+    home_complete = complete_market & (enriched["is_home"].astype(int) == 1)
+    return {
+        "rows": rows,
+        "team_moneyline_rows": int(enriched["team_moneyline"].notna().sum()),
+        "paired_moneyline_rows": int(enriched["opp_moneyline"].notna().sum()),
+        "complete_no_vig_rows": int(complete_market.sum()),
+        "complete_no_vig_share": float(complete_market.mean()) if rows else 0.0,
+        "home_rows": int((enriched["is_home"].astype(int) == 1).sum()),
+        "home_complete_no_vig_rows": int(home_complete.sum()),
+        "home_complete_no_vig_share": (
+            float(home_complete.sum() / max(1, (enriched["is_home"].astype(int) == 1).sum()))
+        ),
+    }

--- a/mlb_research/tests/test_config_validation.py
+++ b/mlb_research/tests/test_config_validation.py
@@ -32,6 +32,7 @@ def test_known_keys_accepted():
         "calibrated": False,
         "calibration_method": "sigmoid",
         "target": "margin",
+        "roi_mode": "moneyline",
     }
     validate_config_keys(config)  # should not raise
 
@@ -95,8 +96,9 @@ def test_validator_runs_via_cli(tmp_path):
 def test_valid_key_whitelists_are_not_empty():
     # Sanity: guarding against accidental wipe of either whitelist.
     assert "target" in VALID_TOP_LEVEL_CONFIG_KEYS
+    assert "roi_mode" in VALID_TOP_LEVEL_CONFIG_KEYS
     assert "n_estimators" in VALID_HYPERPARAM_KEYS
-    assert len(VALID_TOP_LEVEL_CONFIG_KEYS) >= 6
+    assert len(VALID_TOP_LEVEL_CONFIG_KEYS) >= 7
     assert len(VALID_HYPERPARAM_KEYS) >= 8
 
 

--- a/mlb_research/tests/test_espn_odds_backfill.py
+++ b/mlb_research/tests/test_espn_odds_backfill.py
@@ -1,0 +1,105 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "mlb_research" / "anchor_v2"))
+
+from backfill_espn_odds import (  # noqa: E402
+    _extract_moneyline,
+    _select_odds_item,
+    enrich_training_rows,
+)
+
+
+def test_extract_moneyline_prefers_close_then_current_then_open():
+    team_odds = {
+        "moneyLine": 120,
+        "open": {"moneyLine": {"american": "+110"}},
+        "current": {"moneyLine": {"american": "+125"}},
+        "close": {"moneyLine": {"american": "+130"}},
+    }
+    assert _extract_moneyline(team_odds, ["close", "current", "open"]) == (130.0, "close")
+
+
+def test_extract_moneyline_falls_back_to_current():
+    team_odds = {
+        "open": {"moneyLine": {"american": "+110"}},
+        "current": {"moneyLine": {"american": "+125"}},
+    }
+    assert _extract_moneyline(team_odds, ["close", "current", "open"]) == (125.0, "current")
+
+
+def test_select_odds_item_filters_provider_and_requires_both_sides():
+    items = [
+        {
+            "provider": {"name": "Other Book"},
+            "homeTeamOdds": {"close": {"moneyLine": {"american": "-150"}}},
+            "awayTeamOdds": {"close": {"moneyLine": {"american": "+130"}}},
+        },
+        {
+            "provider": {"name": "ESPN BET"},
+            "homeTeamOdds": {"close": {"moneyLine": {"american": "-145"}}},
+            "awayTeamOdds": {"close": {"moneyLine": {"american": "+125"}}},
+        },
+    ]
+    item, home, away, home_basis, away_basis = _select_odds_item(
+        items, "ESPN BET", ["close"]
+    )
+    assert item["provider"]["name"] == "ESPN BET"
+    assert home == -145.0
+    assert away == 125.0
+    assert home_basis == "close"
+    assert away_basis == "close"
+
+
+def test_enrich_training_rows_fills_home_and_away_moneylines():
+    source = pd.DataFrame(
+        [
+            {
+                "date": "2025-04-15",
+                "game_time": "23:05",
+                "team_abbr": "NYY",
+                "opp_abbr": "TOR",
+                "moneyline": float("nan"),
+                "run_line": float("nan"),
+                "total_line": float("nan"),
+            },
+            {
+                "date": "2025-04-15",
+                "game_time": "23:05",
+                "team_abbr": "TOR",
+                "opp_abbr": "NYY",
+                "moneyline": float("nan"),
+                "run_line": float("nan"),
+                "total_line": float("nan"),
+            },
+        ]
+    )
+    odds = pd.DataFrame(
+        [
+            {
+                "date": "2025-04-15",
+                "game_time": "23:05",
+                "home_abbr": "TOR",
+                "away_abbr": "NYY",
+                "home_moneyline": 125.0,
+                "away_moneyline": -145.0,
+                "home_run_line": 1.5,
+                "away_run_line": -1.5,
+                "total_line": 7.5,
+            }
+        ]
+    )
+
+    enriched = enrich_training_rows(source, odds)
+    away = enriched[enriched["team_abbr"] == "NYY"].iloc[0]
+    home = enriched[enriched["team_abbr"] == "TOR"].iloc[0]
+
+    assert away["moneyline"] == pytest.approx(-145.0)
+    assert away["run_line"] == pytest.approx(-1.5)
+    assert home["moneyline"] == pytest.approx(125.0)
+    assert home["run_line"] == pytest.approx(1.5)
+    assert home["total_line"] == pytest.approx(7.5)

--- a/mlb_research/tests/test_espn_odds_backfill.py
+++ b/mlb_research/tests/test_espn_odds_backfill.py
@@ -32,6 +32,12 @@ def test_extract_moneyline_falls_back_to_current():
     assert _extract_moneyline(team_odds, ["close", "current", "open"]) == (125.0, "current")
 
 
+def test_extract_moneyline_uses_top_level_only_when_requested():
+    team_odds = {"moneyLine": -118}
+    assert _extract_moneyline(team_odds, ["close"]) == (None, None)
+    assert _extract_moneyline(team_odds, ["close", "top_level"]) == (-118.0, "top_level")
+
+
 def test_select_odds_item_filters_provider_and_requires_both_sides():
     items = [
         {

--- a/mlb_research/tests/test_market_odds.py
+++ b/mlb_research/tests/test_market_odds.py
@@ -1,0 +1,133 @@
+import math
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from mlb_research.market_odds import (
+    add_market_odds_features,
+    american_odds_profit,
+    american_odds_to_implied_prob,
+    market_coverage_summary,
+    no_vig_probability,
+)
+
+
+def test_american_odds_to_implied_prob():
+    assert american_odds_to_implied_prob("-150") == pytest.approx(0.6)
+    assert american_odds_to_implied_prob("+130") == pytest.approx(100 / 230)
+    assert american_odds_to_implied_prob("EVEN") == pytest.approx(0.5)
+    assert math.isnan(american_odds_to_implied_prob(""))
+
+
+def test_american_odds_profit():
+    assert american_odds_profit("-150") == pytest.approx(100 / 150)
+    assert american_odds_profit("+130") == pytest.approx(1.3)
+    assert american_odds_profit("EVEN") == pytest.approx(1.0)
+    assert math.isnan(american_odds_profit("n/a"))
+
+
+def test_no_vig_probability_normalizes_overround():
+    favorite = american_odds_to_implied_prob("-150")
+    underdog = american_odds_to_implied_prob("+130")
+    assert favorite + underdog > 1.0
+    assert no_vig_probability(favorite, underdog) == pytest.approx(
+        favorite / (favorite + underdog)
+    )
+
+
+def test_add_market_odds_features_pairs_doubleheaders_by_time():
+    df = pd.DataFrame(
+        [
+            {
+                "date": "2025-04-15",
+                "game_time": "13:05",
+                "team": "A",
+                "opponent": "B",
+                "is_home": 1,
+                "moneyline": -150,
+            },
+            {
+                "date": "2025-04-15",
+                "game_time": "13:05",
+                "team": "B",
+                "opponent": "A",
+                "is_home": 0,
+                "moneyline": 130,
+            },
+            {
+                "date": "2025-04-15",
+                "game_time": "19:05",
+                "team": "A",
+                "opponent": "B",
+                "is_home": 1,
+                "moneyline": 110,
+            },
+            {
+                "date": "2025-04-15",
+                "game_time": "19:05",
+                "team": "B",
+                "opponent": "A",
+                "is_home": 0,
+                "moneyline": -120,
+            },
+        ]
+    )
+
+    out = add_market_odds_features(df)
+    early_home = out[(out["team"] == "A") & (out["game_time"] == "13:05")].iloc[0]
+    late_home = out[(out["team"] == "A") & (out["game_time"] == "19:05")].iloc[0]
+
+    assert early_home["opp_moneyline"] == pytest.approx(130)
+    assert late_home["opp_moneyline"] == pytest.approx(-120)
+    assert early_home["market_home_no_vig_prob"] > 0.5
+    assert late_home["market_home_no_vig_prob"] < 0.5
+
+
+def test_market_coverage_summary_counts_complete_pairs():
+    df = pd.DataFrame(
+        [
+            {
+                "date": "2025-04-15",
+                "game_time": "13:05",
+                "team": "A",
+                "opponent": "B",
+                "is_home": 1,
+                "moneyline": -150,
+            },
+            {
+                "date": "2025-04-15",
+                "game_time": "13:05",
+                "team": "B",
+                "opponent": "A",
+                "is_home": 0,
+                "moneyline": 130,
+            },
+            {
+                "date": "2025-04-16",
+                "game_time": "13:05",
+                "team": "C",
+                "opponent": "D",
+                "is_home": 1,
+                "moneyline": float("nan"),
+            },
+            {
+                "date": "2025-04-16",
+                "game_time": "13:05",
+                "team": "D",
+                "opponent": "C",
+                "is_home": 0,
+                "moneyline": float("nan"),
+            },
+        ]
+    )
+
+    summary = market_coverage_summary(df)
+    assert summary["rows"] == 4
+    assert summary["complete_no_vig_rows"] == 2
+    assert summary["complete_no_vig_share"] == pytest.approx(0.5)
+    assert summary["home_complete_no_vig_rows"] == 1

--- a/mlb_research/tests/test_market_odds.py
+++ b/mlb_research/tests/test_market_odds.py
@@ -17,6 +17,14 @@ from mlb_research.market_odds import (
 )
 
 
+def test_external_display_path_is_preserved():
+    sys.path.insert(0, str(REPO_ROOT / "mlb_research" / "anchor_v2"))
+    from build_market_anchor import _display_path
+
+    external = Path("/tmp/mlb_training_data_with_espn_odds.csv")
+    assert _display_path(external) == str(external)
+
+
 def test_american_odds_to_implied_prob():
     assert american_odds_to_implied_prob("-150") == pytest.approx(0.6)
     assert american_odds_to_implied_prob("+130") == pytest.approx(100 / 230)

--- a/mlb_research/tests/test_moneyline_roi.py
+++ b/mlb_research/tests/test_moneyline_roi.py
@@ -1,0 +1,49 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "mlb_research" / "anchor"))
+from anchor_eval import summarize
+
+
+def test_summarize_moneyline_roi_scores_selected_side_prices():
+    preds = pd.DataFrame(
+        {
+            "prob_home": [0.60, 0.40, 0.61],
+            "target": [1, 0, 0],
+            "conf": [0.60, 0.60, 0.61],
+            "home_moneyline": [-150, 120, -110],
+            "away_moneyline": [130, -140, -110],
+        }
+    )
+
+    result = summarize(preds, high_conf_threshold=0.53, roi_mode="moneyline")
+
+    # Win home at -150: +0.6667; win away at -140: +0.7143; lose home: -1.
+    assert result["roi_units"] == pytest.approx((100 / 150) + (100 / 140) - 1)
+    assert result["n_roi_priced"] == 3
+    assert result["n_roi_missing_price"] == 0
+    assert result["n_high_conf"] == 3
+
+
+def test_summarize_moneyline_roi_reports_missing_selected_prices():
+    preds = pd.DataFrame(
+        {
+            "prob_home": [0.60, 0.40],
+            "target": [1, 0],
+            "conf": [0.60, 0.60],
+            "home_moneyline": [-150, 120],
+            "away_moneyline": [np.nan, np.nan],
+        }
+    )
+
+    result = summarize(preds, high_conf_threshold=0.53, roi_mode="moneyline")
+
+    assert result["roi_units"] == pytest.approx(100 / 150)
+    assert result["n_roi_priced"] == 1
+    assert result["n_roi_missing_price"] == 1
+    assert result["n_high_conf"] == 2


### PR DESCRIPTION
Adds vendor-neutral market-odds anchor infrastructure for the next MLB research surface.\n\nWhat changed:\n- Adds market-odds helpers to parse American odds, pair home/away rows, remove vig, and emit market probability features.\n- Adds anchor_v2 builder/diagnostic that refuses to freeze unless paired moneyline coverage clears 95%.\n- Adds optional roi_mode=moneyline support in anchor_eval while preserving flat_110 as default.\n- Documents that Track 2 is blocked on a historical odds source.\n\nCurrent diagnostic on data/mlb_training_data_processed.csv: 0.0% paired moneyline coverage, so freezing correctly fails.\n\nTests:\n- uv run --extra test pytest mlb_research/tests -q -> 88 passed\n- uv run python mlb_research/anchor_v2/build_market_anchor.py -> expected coverage failure