### PR TITLE
Parse FanDuel MONEYLINE settled cards

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -1415,6 +1415,7 @@ def _parse_single_fd_settled_card(card_text: str) -> dict | None:
     league = ""
     wager = 0.0
     odds = "n/a"
+    bet_type = "spread"
 
     for cl in cleaned:
         cl = cl.strip()
@@ -1440,15 +1441,45 @@ def _parse_single_fd_settled_card(card_text: str) -> dict | None:
                 game = f"{g1} vs {g2}"
                 continue
 
+    # Moneyline parsing (when spread parsing failed). FanDuel ML cards
+    # have a different layout from spreads: the bet team appears two lines
+    # above the "MONEYLINE" marker, with the American odds line between them.
+    #
+    # Layout:
+    #     Tampa Bay Rays
+    #     -120
+    #     MONEYLINE
+    if not team:
+        raw_lines = card_text.split("\n")
+        for i in range(2, len(raw_lines)):
+            if raw_lines[i].strip().upper() != "MONEYLINE":
+                continue
+            odds_line = raw_lines[i - 1].strip()
+            team_line = raw_lines[i - 2].strip()
+            ml_odds = re.match(r"^([+-]\d{3,4})$", odds_line)
+            if not ml_odds:
+                continue
+            if not re.match(r"^[A-Z][A-Za-z .'\-()]+$", team_line):
+                continue
+            team = team_line
+            odds = ml_odds.group(1)
+            bet_type = "moneyline"
+            if re.search(r"\(W\)\s*$", team):
+                league = "womens"
+                team = re.sub(r"\s*\(W\)\s*$", "", team).strip()
+            break
+
     # Fallback game detection: in the FanDuel "Finished" format, team names
-    # appear between "SPREAD BETTING" and the wager ($X.XX / TOTAL WAGER).
+    # appear between the bet-type marker (SPREAD BETTING or MONEYLINE) and
+    # the wager ($X.XX / TOTAL WAGER).
     if not game:
+        zone_marker = "MONEYLINE" if bet_type == "moneyline" else "SPREAD BETTING"
         raw_lines = card_text.split("\n")
         game_teams = []
         in_team_zone = False
         for raw_line in raw_lines:
             stripped = raw_line.strip()
-            if "SPREAD BETTING" in stripped.upper():
+            if zone_marker in stripped.upper():
                 in_team_zone = True
                 continue
             if in_team_zone:
@@ -1458,13 +1489,16 @@ def _parse_single_fd_settled_card(card_text: str) -> dict | None:
                     or "BET ID" in stripped.upper()
                 ):
                     break
+                # Strip pitcher parenthetical from "Team Name (Pitcher Name...)"
+                base = re.sub(r"\s*\(.*$", "", stripped).strip()
                 if (
-                    stripped
-                    and re.match(r"^[A-Za-z]", stripped)
-                    and stripped.lower() not in JUNK_LINES
-                    and len(stripped) >= 3
+                    base
+                    and re.match(r"^[A-Za-z]", base)
+                    and base.lower() not in JUNK_LINES
+                    and len(base) >= 3
+                    and base not in game_teams
                 ):
-                    game_teams.append(stripped)
+                    game_teams.append(base)
         if len(game_teams) >= 2:
             # Detect women's league from "(W)" in team names
             if not league and any("(W)" in t for t in game_teams):
@@ -1531,7 +1565,10 @@ def _parse_single_fd_settled_card(card_text: str) -> dict | None:
     else:
         profit = 0.0
 
-    line = f"{team} {spread}" if team and spread else ""
+    if bet_type == "moneyline":
+        line = f"{team} ML" if team else ""
+    else:
+        line = f"{team} {spread}" if team and spread else ""
 
     # 6b. Resolve game date: prediction files take precedence over PLACED date
     if not game_date and team:
@@ -1574,7 +1611,7 @@ def _parse_single_fd_settled_card(card_text: str) -> dict | None:
     return {
         "platform": "FanDuel",
         "game": game,
-        "bet_type": "spread",
+        "bet_type": bet_type,
         "line": line,
         "odds": odds,
         "wager": wager,

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -1459,7 +1459,9 @@ def _parse_single_fd_settled_card(card_text: str) -> dict | None:
             ml_odds = re.match(r"^([+-]\d{3,4})$", odds_line)
             if not ml_odds:
                 continue
-            if not re.match(r"^[A-Z][A-Za-z .'\-()]+$", team_line):
+            # Match the spread parser's character class so teams like
+            # Texas A&M and William & Mary are accepted.
+            if not re.match(r"^[A-Z][A-Za-z &'.()\-]+$", team_line):
                 continue
             team = team_line
             odds = ml_odds.group(1)
@@ -1489,8 +1491,14 @@ def _parse_single_fd_settled_card(card_text: str) -> dict | None:
                     or "BET ID" in stripped.upper()
                 ):
                     break
-                # Strip pitcher parenthetical from "Team Name (Pitcher Name...)"
-                base = re.sub(r"\s*\(.*$", "", stripped).strip()
+                # Strip only an UNCLOSED trailing parenthetical -- that's the
+                # pitcher tag in OCR ("Toronto Blue Jays (EL..."). Closed
+                # parens like "Miami (OH)" or "Team (W)" are real qualifiers
+                # and must be kept so league detection ("(W)") still fires.
+                base = stripped
+                last_open = base.rfind("(")
+                if last_open >= 0 and ")" not in base[last_open:]:
+                    base = base[:last_open].rstrip()
                 if (
                     base
                     and re.match(r"^[A-Za-z]", base)

--- a/tests/fixtures/ocr/fanduel_settled_moneyline.txt
+++ b/tests/fixtures/ocr/fanduel_settled_moneyline.txt
@@ -1,0 +1,39 @@
+9:23
+My Bets
+Open
+Settled
+Saved
+Tampa Bay Rays
+-120
+MONEYLINE
+0 0 1 0 0 0 0 0 0
+Toronto Blue Jays (EL...
+1
+1 2 3 4 5 6 7 8 9
+Finished
+3 0 0 0 0 2 0 0 0
+Tampa Bay Rays (N M...
+5
+$0.50
+$0.92
+TOTAL WAGER
+WON ON FANDUEL
+BET ID: 0/0084650/0000230
+PLACED: 5/4/2026 2:34PM ET
+Los Angeles Angels
+-158
+MONEYLINE
+2 0 0 3 0 0 0 1 0
+6
+Chicago White Sox (D...
+1 2 3 4 5 6 7 8 9
+T
+Finished
+Los Angeles Angels (J...
+0 0 0 0 0 0 0 0 0
+$0.50
+$0.00
+TOTAL WAGER
+RETURNED
+BET ID: 0/0084650/0000232
+PLACED: 5/4/2026 2:34PM ET

--- a/tests/test_telegram_ocr_regression.py
+++ b/tests/test_telegram_ocr_regression.py
@@ -489,6 +489,74 @@ def test_fanduel_settled_dedup_skip_entries() -> None:
 
 
 # ---------------------------------------------------------------------------
+# FanDuel MONEYLINE format tests (no spread number; team and odds split lines)
+# ---------------------------------------------------------------------------
+
+
+def test_fanduel_moneyline_multi_card_parsing() -> None:
+    """ML cards: team appears 2 lines above MONEYLINE marker; odds on the line between."""
+    raw = _read_fixture("fanduel_settled_moneyline.txt")
+    bets = BOT._parse_fd_settled_cards(raw)
+    actual = _actual_bets(bets)
+
+    assert len(actual) == 2
+
+    win = actual[0]
+    assert win["bet_id"] == "0/0084650/0000230"
+    assert win["bet_type"] == "moneyline"
+    assert win["line"] == "Tampa Bay Rays ML"
+    assert win["odds"] == "-120"
+    assert win["wager"] == 0.5
+    assert win["result"] == "win"
+    assert win["payout"] == 0.92
+    assert win["profit"] == 0.42
+    assert win["game"] == "Toronto Blue Jays vs Tampa Bay Rays"
+    assert win["date"] == "2026-05-04"
+
+    loss = actual[1]
+    assert loss["bet_id"] == "0/0084650/0000232"
+    assert loss["bet_type"] == "moneyline"
+    assert loss["line"] == "Los Angeles Angels ML"
+    assert loss["odds"] == "-158"
+    assert loss["wager"] == 0.5
+    # FanDuel "RETURNED" with $0.00 payout reflects a losing bet, not a refund.
+    assert loss["result"] == "loss"
+    assert loss["profit"] == -0.5
+
+
+def test_fanduel_moneyline_underdog_plus_odds() -> None:
+    """Plus-odds ML team should parse and game come from matchup teams."""
+    card = (
+        "Atlanta Braves\n+126\nMONEYLINE\n"
+        "Atlanta Braves (J Ritc...\n1 0 0 0 0 3 0 0 0\n4\n"
+        "Seattle Mariners (L Gil...\n0 0 0 0 0 5 0 0 0\n5\n"
+        "$0.50\n$0.00\nTOTAL WAGER\nRETURNED\n"
+        "BET ID: ML-PLUS-001\nPLACED: 5/4/2026 2:34PM ET\n"
+    )
+    bets = BOT._parse_fd_settled_cards(card)
+    actual = _actual_bets(bets)
+
+    assert len(actual) == 1
+    bet = actual[0]
+    assert bet["bet_type"] == "moneyline"
+    assert bet["line"] == "Atlanta Braves ML"
+    assert bet["odds"] == "+126"
+    assert bet["game"] == "Atlanta Braves vs Seattle Mariners"
+    assert bet["result"] == "loss"
+
+
+def test_fanduel_spread_still_parses_after_ml_changes() -> None:
+    """Existing spread fixtures must keep parsing as bet_type=spread."""
+    raw = _read_fixture("fanduel_settled_multi.txt")
+    bets = BOT._parse_fd_settled_cards(raw)
+    actual = _actual_bets(bets)
+
+    assert len(actual) == 3
+    for b in actual:
+        assert b["bet_type"] == "spread"
+
+
+# ---------------------------------------------------------------------------
 # _ocr_sort_key tests
 # ---------------------------------------------------------------------------
 

--- a/tests/test_telegram_ocr_regression.py
+++ b/tests/test_telegram_ocr_regression.py
@@ -556,6 +556,64 @@ def test_fanduel_spread_still_parses_after_ml_changes() -> None:
         assert b["bet_type"] == "spread"
 
 
+def test_fanduel_moneyline_team_with_ampersand() -> None:
+    """ML team containing '&' (e.g. Texas A&M) must be accepted."""
+    card = (
+        "Texas A&M\n-140\nMONEYLINE\n"
+        "Texas A&M (M Bay...\n2 0 0 0 0 1 0 0 0\n3\n"
+        "Mississippi St. (P Pe...\n0 0 0 0 0 0 0 0 0\n0\n"
+        "$0.50\n$0.86\nTOTAL WAGER\nWON ON FANDUEL\n"
+        "BET ID: ML-AMP-001\nPLACED: 5/5/2026 7:00PM ET\n"
+    )
+    bets = BOT._parse_fd_settled_cards(card)
+    actual = _actual_bets(bets)
+
+    assert len(actual) == 1
+    bet = actual[0]
+    assert bet["bet_type"] == "moneyline"
+    assert bet["line"] == "Texas A&M ML"
+    assert bet["game"] == "Texas A&M vs Mississippi St."
+
+
+def test_fanduel_moneyline_qualified_team_miami_oh() -> None:
+    """Closed-paren qualifier '(OH)' must survive fallback game detection."""
+    card = (
+        "Toledo\n-150\nMONEYLINE\n"
+        "Miami (OH) (B Smi...\n0 0 0 0 0 0 0 0 0\n0\n"
+        "Toledo (R Joh...\n2 0 0 1 0 0 0 0 0\n3\n"
+        "$0.50\n$0.83\nTOTAL WAGER\nWON ON FANDUEL\n"
+        "BET ID: ML-OH-001\nPLACED: 5/5/2026 7:00PM ET\n"
+    )
+    bets = BOT._parse_fd_settled_cards(card)
+    actual = _actual_bets(bets)
+
+    assert len(actual) == 1
+    bet = actual[0]
+    assert bet["bet_type"] == "moneyline"
+    assert bet["line"] == "Toledo ML"
+    assert bet["game"] == "Miami (OH) vs Toledo"
+
+
+def test_fanduel_moneyline_w_qualifier_sets_womens_league() -> None:
+    """'(W)' qualifier in fallback teams must trigger womens league detection."""
+    card = (
+        "South Carolina (W)\n-220\nMONEYLINE\n"
+        "South Carolina (W)\n0 0 0 0 0 0 0 0 0\n78\n"
+        "LSU (W)\n0 0 0 0 0 0 0 0 0\n65\n"
+        "$0.50\n$0.73\nTOTAL WAGER\nWON ON FANDUEL\n"
+        "BET ID: ML-W-001\nPLACED: 5/5/2026 7:00PM ET\n"
+    )
+    bets = BOT._parse_fd_settled_cards(card)
+    actual = _actual_bets(bets)
+
+    assert len(actual) == 1
+    bet = actual[0]
+    assert bet["bet_type"] == "moneyline"
+    assert bet["league"] == "womens"
+    assert bet["line"] == "South Carolina ML"
+    assert bet["game"] == "South Carolina vs LSU"
+
+
 # ---------------------------------------------------------------------------
 # _ocr_sort_key tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- The FD settled-card parser only matched SPREAD bets, so MONEYLINE screenshots came back with empty `line`/`odds` and were silently rejected as \"Could not parse settled bet fully.\"
- Add an ML branch: when no spread is detected, look for a `MONEYLINE` marker and grab the bet team two lines above it with the American odds on the line between.
- Generalize the matchup-zone fallback so it walks team lines under either `SPREAD BETTING` or `MONEYLINE`. Pitcher parentheticals (`Atlanta Braves (J Ritc...)`) are stripped before the team is added.
- Returned `bet_type` is now per-card (`spread` or `moneyline`) and the line is rendered as `Team ML` for moneylines.

## Background
The MLB pilot started placing FanDuel ML bets on 2026-05-04. The bot OCR'd the settled cards but the parser produced no usable team/odds for any of the 7, so none were appended to `betting_history.csv`. Backfilling those 7 rows is a separate local-only step (the ledger is gitignored).

## Test plan
- [x] `uv run --extra test pytest tests/test_telegram_ocr_regression.py -q` -- 36 passed
- [x] `uv run --extra test pytest -q` -- 775 passed
- [ ] After merge, send a real MLB ML settled screenshot to the bot and confirm rows land with `bet_type=moneyline` and the right team / odds.

## New tests
- `test_fanduel_moneyline_multi_card_parsing` -- end-to-end on a real-OCR fixture (TB Rays win + LAA loss).
- `test_fanduel_moneyline_underdog_plus_odds` -- plus-odds team and matchup extracted from pitcher-tagged team lines.
- `test_fanduel_spread_still_parses_after_ml_changes` -- existing spread fixtures still return `bet_type=spread`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)