### PR TITLE
Normalize bet_type to moneyline (Kalshi, Polymarket, FanDuel)

### DIFF
--- a/backtest_kalshi_game.py
+++ b/backtest_kalshi_game.py
@@ -91,9 +91,11 @@ def load_actual_betting_history_rows(csv_path: str, league: str | None = None) -
     df = pd.read_csv(csv_path)
     df["platform"] = df["platform"].astype(str).str.lower()
     df["bet_type"] = df["bet_type"].astype(str).str.lower()
+    # Accept both "moneyline" (current canonical) and "game" (legacy, pre-rename)
+    # so unmigrated external ledgers still load.
     settled = df[
         (df["platform"] == "kalshi")
-        & (df["bet_type"] == "game")
+        & df["bet_type"].isin({"moneyline", "game"})
         & df["result"].astype(str).str.lower().isin({"win", "loss", "void"})
     ].copy()
     if league is not None:

--- a/settle_bets.py
+++ b/settle_bets.py
@@ -35,8 +35,8 @@ def parse_bet_line(line_str):
         "Providence +15.5"      -> {team: "Providence", spread: 15.5, side: None, bet_type: "spread"}
         "UConn -15.5 NO"        -> {team: "UConn", spread: -15.5, side: "NO", bet_type: "spread"}
         "Furman -10.5 YES"      -> {team: "Furman", spread: -10.5, side: "YES", bet_type: "spread"}
-        "South Carolina ML YES" -> {team: "South Carolina", spread: None, side: "YES", bet_type: "game"}
-        "UConn ML"              -> {team: "UConn", spread: None, side: None, bet_type: "game"}
+        "South Carolina ML YES" -> {team: "South Carolina", spread: None, side: "YES", bet_type: "moneyline"}
+        "UConn ML"              -> {team: "UConn", spread: None, side: None, bet_type: "moneyline"}
     """
     line_str = str(line_str).strip()
 

--- a/settle_bets.py
+++ b/settle_bets.py
@@ -68,14 +68,14 @@ def parse_bet_line(line_str):
     game_match = re.match(r"^(.+?)\s+(?:ML|MONEYLINE|GAME)$", line_str, re.IGNORECASE)
     if game_match:
         team = game_match.group(1).strip()
-        return {"team": team, "spread": None, "side": side, "bet_type": "game"}
+        return {"team": team, "spread": None, "side": side, "bet_type": "moneyline"}
 
     # Split off the spread (last token should be +/- number)
     match = re.match(r"^(.+?)\s+([+-]?\d+\.?\d*)$", line_str)
     if not match:
         # Support explicit YES/NO game lines without "ML" suffix.
         if side in {"YES", "NO"} and line_str:
-            return {"team": line_str, "spread": None, "side": side, "bet_type": "game"}
+            return {"team": line_str, "spread": None, "side": side, "bet_type": "moneyline"}
         return None
 
     team = match.group(1).strip()
@@ -176,7 +176,7 @@ def determine_bet_result(parsed_line, game_result, game_str):
     if not picked_home and not picked_away:
         return None
 
-    if bet_type == "game":
+    if bet_type == "moneyline":
         # Winner market:
         # - side YES or no side: team must win
         # - side NO: team must lose

--- a/settle_kalshi.py
+++ b/settle_kalshi.py
@@ -44,7 +44,7 @@ def _bet_type_from_ticker(ticker: str) -> str:
     if "SPREAD" in upper:
         return "spread"
     if "GAME" in upper:
-        return "game"
+        return "moneyline"
     if "TOTAL" in upper:
         return "total"
     return "other"

--- a/settle_polymarket.py
+++ b/settle_polymarket.py
@@ -127,7 +127,7 @@ def _parse_position(pos: dict) -> dict | None:
     elif "total" in title_lower or "over" in title_lower or "under" in title_lower or "o/u" in title_lower:
         bet_type = "total"
     else:
-        bet_type = "game"
+        bet_type = "moneyline"
 
     side = pos.get("side", "YES").upper()
 

--- a/tests/test_backtest_kalshi_game.py
+++ b/tests/test_backtest_kalshi_game.py
@@ -221,8 +221,8 @@ def test_load_actual_betting_history_results(tmp_path):
     csv_path = tmp_path / "betting_history.csv"
     csv_path.write_text(
         "date,platform,game,bet_type,line,odds,wager,result,payout,profit,bet_id,league\n"
-        "2026-03-02,Kalshi,Oklahoma at Missouri Winner?,game,Missouri ML,,0.11,loss,0.0,-0.11,KXNCAAWBGAME-26MAR01OKLAMIZZ-MIZZ,womens\n"
-        "2026-03-04,Kalshi,North Texas at Wichita St. Winner?,game,Wichita St. ML,,1.20,win,8.0,6.80,KXNCAAWBGAME-26MAR03UNTWICH-WICH,womens\n"
+        "2026-03-02,Kalshi,Oklahoma at Missouri Winner?,moneyline,Missouri ML,,0.11,loss,0.0,-0.11,KXNCAAWBGAME-26MAR01OKLAMIZZ-MIZZ,womens\n"
+        "2026-03-04,Kalshi,North Texas at Wichita St. Winner?,moneyline,Wichita St. ML,,1.20,win,8.0,6.80,KXNCAAWBGAME-26MAR03UNTWICH-WICH,womens\n"
     )
 
     results = load_actual_betting_history_results(str(csv_path), league="womens")
@@ -234,22 +234,24 @@ def test_load_actual_betting_history_results(tmp_path):
 
 
 def test_load_actual_betting_history_rows_filters_kalshi_game(tmp_path):
+    """Loader accepts both the new "moneyline" bet_type and legacy "game" rows."""
     csv_path = tmp_path / "betting_history.csv"
     csv_path.write_text(
         "date,platform,game,bet_type,line,odds,wager,result,payout,profit,bet_id,league\n"
-        "2026-03-02,Kalshi,Game A,game,Team A ML,,0.11,loss,0.0,-0.11,TICKER1,mens\n"
+        "2026-03-02,Kalshi,Game A,moneyline,Team A ML,,0.11,loss,0.0,-0.11,TICKER1,mens\n"
+        "2026-03-02,Kalshi,Game C,game,Team C ML,,0.11,loss,0.0,-0.11,TICKER3,mens\n"
         "2026-03-02,FanDuel,Game B,spread,Team B -3.5,-110,1.10,win,2.10,1.00,BET2,mens\n"
     )
     rows = load_actual_betting_history_rows(str(csv_path), league="mens")
-    assert len(rows) == 1
-    assert rows.iloc[0]["bet_id"] == "TICKER1"
+    assert len(rows) == 2
+    assert set(rows["bet_id"]) == {"TICKER1", "TICKER3"}
 
 
 def test_compare_actual_bets_to_archived_predictions_matches_on_ticker(tmp_path):
     csv_path = tmp_path / "betting_history.csv"
     csv_path.write_text(
         "date,platform,game,bet_type,line,odds,wager,result,payout,profit,bet_id,league\n"
-        "2026-03-10,Kalshi,Providence Friars @ UConn Huskies,game,UConn Huskies ML YES,,0.58,win,1.0,0.42,TICKER1,mens\n"
+        "2026-03-10,Kalshi,Providence Friars @ UConn Huskies,moneyline,UConn Huskies ML YES,,0.58,win,1.0,0.42,TICKER1,mens\n"
     )
     archived = pd.DataFrame(
         [

--- a/tests/test_settle_bets.py
+++ b/tests/test_settle_bets.py
@@ -76,17 +76,17 @@ class TestParseBetLine:
     def test_game_market_yes(self):
         """Kalshi GAME market YES line."""
         result = parse_bet_line("South Carolina ML YES")
-        assert result == {"team": "South Carolina", "spread": None, "side": "YES", "bet_type": "game"}
+        assert result == {"team": "South Carolina", "spread": None, "side": "YES", "bet_type": "moneyline"}
 
     def test_game_market_no(self):
         """Kalshi GAME market NO line."""
         result = parse_bet_line("UConn ML NO")
-        assert result == {"team": "UConn", "spread": None, "side": "NO", "bet_type": "game"}
+        assert result == {"team": "UConn", "spread": None, "side": "NO", "bet_type": "moneyline"}
 
     def test_game_market_bare_ml(self):
         """Bare ML line defaults to YES semantics for game market."""
         result = parse_bet_line("UConn ML")
-        assert result == {"team": "UConn", "spread": None, "side": None, "bet_type": "game"}
+        assert result == {"team": "UConn", "spread": None, "side": None, "bet_type": "moneyline"}
 
 
 class TestDetermineBetResult:
@@ -236,7 +236,7 @@ class TestDetermineBetResult:
 
     def test_game_yes_win(self):
         """GAME YES wins when team wins."""
-        parsed = {"team": "UConn", "spread": None, "side": "YES", "bet_type": "game"}
+        parsed = {"team": "UConn", "spread": None, "side": "YES", "bet_type": "moneyline"}
         game = {
             "home_score": 80,
             "away_score": 70,
@@ -248,7 +248,7 @@ class TestDetermineBetResult:
 
     def test_game_no_win(self):
         """GAME NO wins when team loses."""
-        parsed = {"team": "UConn", "spread": None, "side": "NO", "bet_type": "game"}
+        parsed = {"team": "UConn", "spread": None, "side": "NO", "bet_type": "moneyline"}
         game = {
             "home_score": 70,
             "away_score": 75,
@@ -260,7 +260,7 @@ class TestDetermineBetResult:
 
     def test_game_yes_loss(self):
         """GAME YES loses when team loses."""
-        parsed = {"team": "UConn", "spread": None, "side": "YES", "bet_type": "game"}
+        parsed = {"team": "UConn", "spread": None, "side": "YES", "bet_type": "moneyline"}
         game = {
             "home_score": 68,
             "away_score": 72,
@@ -272,7 +272,7 @@ class TestDetermineBetResult:
 
     def test_game_no_loss(self):
         """GAME NO loses when team wins."""
-        parsed = {"team": "UConn", "spread": None, "side": "NO", "bet_type": "game"}
+        parsed = {"team": "UConn", "spread": None, "side": "NO", "bet_type": "moneyline"}
         game = {
             "home_score": 80,
             "away_score": 70,
@@ -284,7 +284,7 @@ class TestDetermineBetResult:
 
     def test_game_tie_void(self):
         """GAME market should void if score tie is returned."""
-        parsed = {"team": "UConn", "spread": None, "side": "YES", "bet_type": "game"}
+        parsed = {"team": "UConn", "spread": None, "side": "YES", "bet_type": "moneyline"}
         game = {
             "home_score": 75,
             "away_score": 75,
@@ -296,7 +296,7 @@ class TestDetermineBetResult:
 
     def test_game_away_team_yes_win(self):
         """GAME YES works when the picked team is away."""
-        parsed = {"team": "Providence", "spread": None, "side": "YES", "bet_type": "game"}
+        parsed = {"team": "Providence", "spread": None, "side": "YES", "bet_type": "moneyline"}
         game = {
             "home_score": 70,
             "away_score": 75,

--- a/tests/test_settle_kalshi.py
+++ b/tests/test_settle_kalshi.py
@@ -48,7 +48,7 @@ class TestBetTypeFromTicker:
         assert _bet_type_from_ticker("KXNCAAMBSPREAD-26JAN10TEXALA-ALA13") == "spread"
 
     def test_game(self):
-        assert _bet_type_from_ticker("KXNCAAWBGAME-26MAR01OKLAMIZZ-MIZZ") == "game"
+        assert _bet_type_from_ticker("KXNCAAWBGAME-26MAR01OKLAMIZZ-MIZZ") == "moneyline"
 
     def test_total(self):
         assert _bet_type_from_ticker("KXNCAAMBTOTAL-26JAN10-O150") == "total"

--- a/tests/test_settle_polymarket.py
+++ b/tests/test_settle_polymarket.py
@@ -66,7 +66,7 @@ class TestParsePosition:
 
     def test_bet_type_game_from_title(self):
         row = _parse_position(self._pos(title="Yankees vs Red Sox"))
-        assert row["bet_type"] == "game"
+        assert row["bet_type"] == "moneyline"
 
     def test_bet_type_spread_from_title(self):
         row = _parse_position(self._pos(title="Spread: Red Sox (-1.5)"))


### PR DESCRIPTION
## Summary
- Kalshi GAME tickers and Polymarket winner markets previously wrote `bet_type=game` while the new FanDuel ML parser writes `bet_type=moneyline`. This unifies them so cross-platform analytics can group all ML bets without special-casing the Kalshi/Poly vocabulary.
- `settle_kalshi.py`, `settle_polymarket.py`, and `settle_bets.py` (the FanDuel grading helpers `parse_bet_line` / `determine_bet_result`) now produce/consume `moneyline`.
- 109 existing Kalshi rows in `data/betting_history.csv` (gitignored, local-only ledger) were migrated `game` -> `moneyline` locally; CRLF line endings preserved.
- `bet_type` is purely a ledger field. The model-side `Bet_Type` (capital) on `predictions.csv` is a separate domain and is intentionally **not** changed in this PR.

## Test plan
- [x] `uv run --extra test pytest -q` -- 772 passed
- [x] Spot-check ledger after migration: Kalshi MLB rows show `bet_type=moneyline`, no rows remain with `bet_type=game`
- [ ] After merge, run `/settle` once on Kalshi to confirm new fills land with `bet_type=moneyline`