### PR TITLE
FanDuel ML: handle reversed odds/team layout, auto-tag MLB league

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -139,6 +139,21 @@ JUNK_LINES = {
     "home", "account", "saved", "live now", "spread betting", "total wager",
 }
 
+# Full MLB team display names (lowercase) for league auto-detection on
+# moneyline cards. Sourced from mlb/data.py:MLB_TEAM_IDS keys.
+_MLB_TEAM_NAMES_LOWER = {
+    "arizona diamondbacks", "atlanta braves", "baltimore orioles",
+    "boston red sox", "chicago cubs", "chicago white sox",
+    "cincinnati reds", "cleveland guardians", "colorado rockies",
+    "detroit tigers", "houston astros", "kansas city royals",
+    "los angeles angels", "los angeles dodgers", "miami marlins",
+    "milwaukee brewers", "minnesota twins", "new york mets",
+    "new york yankees", "oakland athletics", "philadelphia phillies",
+    "pittsburgh pirates", "san diego padres", "san francisco giants",
+    "seattle mariners", "st. louis cardinals", "tampa bay rays",
+    "texas rangers", "toronto blue jays", "washington nationals",
+}
+
 # Regex patterns for junk OCR lines
 JUNK_PATTERNS = [
     re.compile(r"^\d{1,2}:\d{2}\s*(AM|PM)?$", re.IGNORECASE),  # timestamps
@@ -1442,29 +1457,28 @@ def _parse_single_fd_settled_card(card_text: str) -> dict | None:
                 continue
 
     # Moneyline parsing (when spread parsing failed). FanDuel ML cards
-    # have a different layout from spreads: the bet team appears two lines
-    # above the "MONEYLINE" marker, with the American odds line between them.
-    #
-    # Layout:
-    #     Tampa Bay Rays
-    #     -120
-    #     MONEYLINE
+    # place the team and American odds on the two lines preceding the
+    # "MONEYLINE" marker. The order of those two lines is not stable --
+    # most cards render team then odds, but some screenshots flip them.
+    # Identify each line by its content (odds regex vs team regex) rather
+    # than by position.
     if not team:
         raw_lines = card_text.split("\n")
+        odds_re = re.compile(r"^([+-]\d{3,4})$")
+        team_re = re.compile(r"^[A-Z][A-Za-z &'.()\-]+$")
         for i in range(2, len(raw_lines)):
             if raw_lines[i].strip().upper() != "MONEYLINE":
                 continue
-            odds_line = raw_lines[i - 1].strip()
-            team_line = raw_lines[i - 2].strip()
-            ml_odds = re.match(r"^([+-]\d{3,4})$", odds_line)
-            if not ml_odds:
-                continue
-            # Match the spread parser's character class so teams like
-            # Texas A&M and William & Mary are accepted.
-            if not re.match(r"^[A-Z][A-Za-z &'.()\-]+$", team_line):
+            l1 = raw_lines[i - 2].strip()
+            l2 = raw_lines[i - 1].strip()
+            if odds_re.match(l2) and team_re.match(l1):
+                team_line, odds_line = l1, l2
+            elif odds_re.match(l1) and team_re.match(l2):
+                team_line, odds_line = l2, l1
+            else:
                 continue
             team = team_line
-            odds = ml_odds.group(1)
+            odds = odds_re.match(odds_line).group(1)
             bet_type = "moneyline"
             if re.search(r"\(W\)\s*$", team):
                 league = "womens"
@@ -1514,6 +1528,14 @@ def _parse_single_fd_settled_card(card_text: str) -> dict | None:
             gt0 = re.sub(r"\s*\(W\)\s*$", "", game_teams[0]).strip()
             gt1 = re.sub(r"\s*\(W\)\s*$", "", game_teams[1]).strip()
             game = f"{gt0} vs {gt1}"
+
+    # MLB league auto-detection: for moneyline cards without an existing
+    # league tag, mark league=mlb when the bet team matches a known MLB
+    # franchise name. CBB moneyline picks won't match (e.g. "Houston" alone
+    # is not "Houston Astros") and women's bets are already tagged above.
+    if bet_type == "moneyline" and not league and team:
+        if team.strip().lower() in _MLB_TEAM_NAMES_LOWER:
+            league = "mlb"
 
     # Wager: first dollar amount in range from cleaned text
     for cl in cleaned:

--- a/tests/test_telegram_ocr_regression.py
+++ b/tests/test_telegram_ocr_regression.py
@@ -594,6 +594,66 @@ def test_fanduel_moneyline_qualified_team_miami_oh() -> None:
     assert bet["game"] == "Miami (OH) vs Toledo"
 
 
+def test_fanduel_moneyline_reversed_odds_team_layout() -> None:
+    """Some FanDuel ML cards render '<odds>\\n<team>\\nMONEYLINE' instead of the
+    standard '<team>\\n<odds>\\nMONEYLINE'. Both layouts must parse."""
+    card = (
+        "-112\nSan Diego Padres\nMONEYLINE\n"
+        "San Diego Padres (B...\n0 0 0 1 0 0 2 2 0\n5\n"
+        "San Francisco Giants (D...\n0 0 0 1 0 0 0 0 1\n2\n"
+        "$0.50\n$0.95\nTOTAL WAGER\nWON ON FANDUEL\n"
+        "BET ID: ML-REV-001\nPLACED: 5/6/2026 2:22PM ET\n"
+    )
+    bets = BOT._parse_fd_settled_cards(card)
+    actual = _actual_bets(bets)
+
+    assert len(actual) == 1
+    bet = actual[0]
+    assert bet["bet_type"] == "moneyline"
+    assert bet["line"] == "San Diego Padres ML"
+    assert bet["odds"] == "-112"
+    assert bet["game"] == "San Diego Padres vs San Francisco Giants"
+    assert bet["result"] == "win"
+
+
+def test_fanduel_moneyline_mlb_team_sets_league_mlb() -> None:
+    """ML cards on a known MLB franchise should tag league=mlb."""
+    card = (
+        "Tampa Bay Rays\n-120\nMONEYLINE\n"
+        "Toronto Blue Jays (EL...\n0 0 1 0 0 0 0 0 0\n1\n"
+        "Tampa Bay Rays (N M...\n3 0 0 0 0 2 0 0 0\n5\n"
+        "$0.50\n$0.92\nTOTAL WAGER\nWON ON FANDUEL\n"
+        "BET ID: ML-MLB-001\nPLACED: 5/4/2026 2:34PM ET\n"
+    )
+    bets = BOT._parse_fd_settled_cards(card)
+    actual = _actual_bets(bets)
+
+    assert len(actual) == 1
+    assert actual[0]["league"] == "mlb"
+    assert actual[0]["line"] == "Tampa Bay Rays ML"
+
+
+def test_fanduel_moneyline_cbb_team_no_league_tag() -> None:
+    """ML cards on a non-MLB, non-(W) team must NOT auto-tag league=mlb."""
+    card = (
+        "Houston\n-150\nMONEYLINE\n"
+        "Houston\n78\n"
+        "Memphis\n65\n"
+        "$0.50\n$0.83\nTOTAL WAGER\nWON ON FANDUEL\n"
+        "BET ID: ML-CBB-001\nPLACED: 3/15/2026 7:00PM ET\n"
+    )
+    bets = BOT._parse_fd_settled_cards(card)
+    actual = _actual_bets(bets)
+
+    assert len(actual) == 1
+    bet = actual[0]
+    assert bet["bet_type"] == "moneyline"
+    assert bet["line"] == "Houston ML"
+    # "Houston" alone is not an MLB franchise name ("Houston Astros" is),
+    # so league should stay empty for the CBB-style bet.
+    assert bet["league"] == ""
+
+
 def test_fanduel_moneyline_w_qualifier_sets_womens_league() -> None:
     """'(W)' qualifier in fallback teams must trigger womens league detection."""
     card = (


### PR DESCRIPTION
## Summary
Two follow-up fixes to the FanDuel MONEYLINE parser, surfaced by 5/6 MLB screenshots where 1 of 3 ML wins was missed and the 2 successful parses had no league tag.

- **Reversed odds/team layout.** Most FanDuel ML cards render `<team>\n<odds>\nMONEYLINE`, but some screenshots flip those two lines. The parser now identifies each line by content (odds vs team regex) instead of position, so either ordering parses.
- **`league=mlb` auto-detection.** ML cards on a known MLB franchise (full display name) are now tagged `league=mlb`. CBB ML picks like bare "Houston" don't match (they're not "Houston Astros"), so they continue to parse with no league tag and don't get falsely promoted.

The MLB team list is duplicated locally in `telegram_bot.py` rather than imported from `mlb/data.py` to avoid pulling pandas/heavy deps into the bot module.

## Test plan
- [x] `uv run --extra test pytest -q` -- 781 passed
- [x] New tests:
  - `test_fanduel_moneyline_reversed_odds_team_layout`
  - `test_fanduel_moneyline_mlb_team_sets_league_mlb`
  - `test_fanduel_moneyline_cbb_team_no_league_tag`
- [ ] After merge, re-send a 5/6 ML screenshot to confirm San Diego Padres-style cards now parse cleanly with `league=mlb`