### PR TITLE
FanDuel ML: tolerate OCR noise line between odds and MONEYLINE

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -1457,11 +1457,15 @@ def _parse_single_fd_settled_card(card_text: str) -> dict | None:
                 continue
 
     # Moneyline parsing (when spread parsing failed). FanDuel ML cards
-    # place the team and American odds on the two lines preceding the
-    # "MONEYLINE" marker. The order of those two lines is not stable --
-    # most cards render team then odds, but some screenshots flip them.
-    # Identify each line by its content (odds regex vs team regex) rather
-    # than by position.
+    # render team/odds on the few lines preceding the "MONEYLINE" marker.
+    # Two complications observed in the wild:
+    #   * Order of team and odds isn't stable (most cards: team then odds;
+    #     some screenshots flip them).
+    #   * A spurious single-character OCR line (e.g. "R") can sit between
+    #     the team/odds pair and "MONEYLINE", pushing the anchor block to
+    #     i-3/i-2 instead of i-2/i-1.
+    # Locate odds first by scanning lines i-1, i-2, i-3, then take the
+    # team line as the immediate neighbor that matches the team regex.
     if not team:
         raw_lines = card_text.split("\n")
         odds_re = re.compile(r"^([+-]\d{3,4})$")
@@ -1469,16 +1473,24 @@ def _parse_single_fd_settled_card(card_text: str) -> dict | None:
         for i in range(2, len(raw_lines)):
             if raw_lines[i].strip().upper() != "MONEYLINE":
                 continue
-            l1 = raw_lines[i - 2].strip()
-            l2 = raw_lines[i - 1].strip()
-            if odds_re.match(l2) and team_re.match(l1):
-                team_line, odds_line = l1, l2
-            elif odds_re.match(l1) and team_re.match(l2):
-                team_line, odds_line = l2, l1
-            else:
+            odds_idx = None
+            for offset in (1, 2, 3):
+                if i - offset < 0:
+                    break
+                if odds_re.match(raw_lines[i - offset].strip()):
+                    odds_idx = i - offset
+                    break
+            if odds_idx is None:
                 continue
-            team = team_line
-            odds = odds_re.match(odds_line).group(1)
+            team_idx = None
+            for cand in (odds_idx - 1, odds_idx + 1):
+                if 0 <= cand < i and team_re.match(raw_lines[cand].strip()):
+                    team_idx = cand
+                    break
+            if team_idx is None:
+                continue
+            team = raw_lines[team_idx].strip()
+            odds = odds_re.match(raw_lines[odds_idx].strip()).group(1)
             bet_type = "moneyline"
             if re.search(r"\(W\)\s*$", team):
                 league = "womens"

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -1482,13 +1482,19 @@ def _parse_single_fd_settled_card(card_text: str) -> dict | None:
                     break
             if odds_idx is None:
                 continue
-            team_idx = None
-            for cand in (odds_idx - 1, odds_idx + 1):
-                if 0 <= cand < i and team_re.match(raw_lines[cand].strip()):
-                    team_idx = cand
-                    break
-            if team_idx is None:
+            # Team line is one of the two odds-neighbors. When both match
+            # team_re (rare; happens when noise above odds happens to look
+            # like a team name), prefer the candidate closer to MONEYLINE:
+            # in the reversed layout that's the real team, and the standard
+            # layout never makes odds_idx+1 a match (it's MONEYLINE itself,
+            # which is excluded by `cand < i`).
+            matches = [
+                cand for cand in (odds_idx - 1, odds_idx + 1)
+                if 0 <= cand < i and team_re.match(raw_lines[cand].strip())
+            ]
+            if not matches:
                 continue
+            team_idx = max(matches)
             team = raw_lines[team_idx].strip()
             odds = odds_re.match(raw_lines[odds_idx].strip()).group(1)
             bet_type = "moneyline"

--- a/tests/test_telegram_ocr_regression.py
+++ b/tests/test_telegram_ocr_regression.py
@@ -616,6 +616,30 @@ def test_fanduel_moneyline_reversed_odds_team_layout() -> None:
     assert bet["result"] == "win"
 
 
+def test_fanduel_moneyline_noise_line_between_odds_and_marker() -> None:
+    """A spurious single-character OCR line between odds and MONEYLINE must
+    not break ML parsing. Reproduces the 5/9 Colorado Rockies failure where
+    'R' sat at i-1 above MONEYLINE, pushing the team/odds anchor to i-3/i-2.
+    """
+    card = (
+        "Colorado Rockies\n+184\nR\nMONEYLINE\n"
+        "Colorado Rockies (C...\n5 0 0 1 0 0 0 2\n9\n"
+        "Philadelphia Phillies (J...\n0 0 0 2 0 5 0 0 0\n7\n"
+        "$0.50\n$1.42\nTOTAL WAGER\nWON ON FANDUEL\n"
+        "BET ID: ML-NOISE-001\nPLACED: 5/8/2026 9:14AM ET\n"
+    )
+    bets = BOT._parse_fd_settled_cards(card)
+    actual = _actual_bets(bets)
+
+    assert len(actual) == 1
+    bet = actual[0]
+    assert bet["bet_type"] == "moneyline"
+    assert bet["line"] == "Colorado Rockies ML"
+    assert bet["odds"] == "+184"
+    assert bet["league"] == "mlb"
+    assert bet["result"] == "win"
+
+
 def test_fanduel_moneyline_mlb_team_sets_league_mlb() -> None:
     """ML cards on a known MLB franchise should tag league=mlb."""
     card = (

--- a/tests/test_telegram_ocr_regression.py
+++ b/tests/test_telegram_ocr_regression.py
@@ -640,6 +640,56 @@ def test_fanduel_moneyline_noise_line_between_odds_and_marker() -> None:
     assert bet["result"] == "win"
 
 
+def test_fanduel_moneyline_noise_line_with_garbled_header() -> None:
+    """Replays the literal 5/9 Colorado Rockies OCR -- garbled scroll-clipped
+    header text above the first card AND a 'R' noise line between odds and
+    MONEYLINE. The wider scan window must not be fooled by header lines that
+    happen to satisfy team_re into picking the wrong team.
+    """
+    card = (
+        "9:00\nMy Bets\nOpen\nSettled\nSaved\n"
+        "ULTIU. VIVVUTUVVIVUVVLTT\nVIUILULU\n.....\n"
+        "FANDUEL\nSPORTSBOOK\n"
+        "Colorado Rockies\n+184\nR\nMONEYLINE\n"
+        "Colorado Rockies (C...\n5 0 0 1 0 0 0 2\n9\n"
+        "Philadelphia Phillies (J...\n0 0 0 2 0 5 0 0 0\n7\n"
+        "$0.50\n$1.42\nTOTAL WAGER\nWON ON FANDUEL\n"
+        "BET ID: ML-NOISE-002\nPLACED: 5/8/2026 9:14AM ET\n"
+    )
+    bets = BOT._parse_fd_settled_cards(card)
+    actual = _actual_bets(bets)
+
+    assert len(actual) == 1
+    bet = actual[0]
+    assert bet["bet_type"] == "moneyline"
+    assert bet["line"] == "Colorado Rockies ML"
+    assert bet["odds"] == "+184"
+
+
+def test_fanduel_moneyline_reversed_layout_with_noise_line() -> None:
+    """Reversed odds/team layout combined with a noise line between team and
+    MONEYLINE. Real team is at odds_idx+1; verify we don't pick a stale
+    team-shaped line at odds_idx-1.
+    """
+    card = (
+        "FANDUEL\nSPORTSBOOK\n"
+        "+118\nTampa Bay Rays\nT\nMONEYLINE\n"
+        "Tampa Bay Rays (J Sc...\n0 0 1 0 0 0 0 0 0\n1\n"
+        "Boston Red Sox (C Ea...\n0 0 1 1 0 0 0 0 0\n2\n"
+        "$0.50\n$0.00\nTOTAL WAGER\nRETURNED\n"
+        "BET ID: ML-REV-NOISE-001\nPLACED: 5/8/2026 9:14AM ET\n"
+    )
+    bets = BOT._parse_fd_settled_cards(card)
+    actual = _actual_bets(bets)
+
+    assert len(actual) == 1
+    bet = actual[0]
+    assert bet["bet_type"] == "moneyline"
+    assert bet["line"] == "Tampa Bay Rays ML"
+    assert bet["odds"] == "+118"
+    assert bet["league"] == "mlb"
+
+
 def test_fanduel_moneyline_mlb_team_sets_league_mlb() -> None:
     """ML cards on a known MLB franchise should tag league=mlb."""
     card = (


### PR DESCRIPTION
## Summary
A 5/9 Colorado Rockies card was dropped by the parser because the OCR rendered:

\`\`\`
Colorado Rockies
+184
R
MONEYLINE
\`\`\`

The previous parser only checked the two lines immediately above \`MONEYLINE\`. With the spurious "R" at i-1, both layout candidates (team/odds and odds/team) failed and the card fell through with empty fields. Result: bet_id 0000241 (won \$1.42 on \$0.50) hit the audit log but never landed in the ledger.

The new logic locates the odds line by scanning i-1, i-2, i-3 above \`MONEYLINE\`, then takes the team line as the immediate odds-neighbor that matches the team regex. Standard, reversed, and noise-line layouts now share a single code path.

## Test plan
- [x] \`uv run --extra test pytest -q\` -- 782 passed
- [x] New test \`test_fanduel_moneyline_noise_line_between_odds_and_marker\` covers the literal Rockies failure pattern
- [x] All earlier ML tests (standard layout, reversed layout, A&M, Miami (OH), (W) womens, MLB league auto-tag, CBB no-tag) still pass
- [ ] After merge, send a reproduction screenshot to confirm live ingestion now captures cards with the same OCR noise pattern

## Note
0000241 has been backfilled into the local ledger out-of-band (\`data/betting_history.csv\` is gitignored).