### PR TITLE
Shadow grader: live-fetch outcomes for dates not in training CSV

### DIFF
--- a/mlb/predict.py
+++ b/mlb/predict.py
@@ -856,7 +856,10 @@ def _refresh_shadow_grader_ledger():
     """
     try:
         from mlb.shadow_grader import grade, write_ledger
-        ledger = grade()
+        # fetch_live=True so the nightly refresh fills in any archive dates
+        # the training CSV doesn't yet cover. The library default is False
+        # to keep tests/offline callers off the network; this caller opts in.
+        ledger = grade(fetch_live=True)
         write_ledger(ledger)
         print(f"   Shadow grader: {len(ledger)} ledger rows refreshed")
     except Exception as e:

--- a/mlb/shadow_grader.py
+++ b/mlb/shadow_grader.py
@@ -370,6 +370,12 @@ def grade(
     outcomes = load_outcomes(processed_csv)
 
     if fetch_live and archives:
+        # Live rows are appended only for dates the CSV doesn't cover at all.
+        # That keeps doubleheader disambiguation in _select_outcome correct:
+        # if any CSV row exists for a date, all rows for that date come from
+        # the CSV (single time convention). A future partial CSV refresh that
+        # only writes one row of a doubleheader would mix conventions; this
+        # invariant prevents that.
         csv_dates = set(outcomes["date"].unique())
         missing = sorted({date_iso for date_iso, _ in archives if date_iso not in csv_dates})
         live_frames = []

--- a/mlb/shadow_grader.py
+++ b/mlb/shadow_grader.py
@@ -122,6 +122,46 @@ def load_outcomes(processed_csv: str) -> pd.DataFrame:
     return out
 
 
+_OUTCOMES_COLS = ["date", "home_team", "away_team", "game_time", "home_win"]
+
+
+def fetch_outcomes_for_date(date_str: str) -> pd.DataFrame:
+    """Fetch finalized game outcomes for a single date from the ESPN scoreboard.
+
+    Mirrors the schema returned by load_outcomes() so the two can be
+    concatenated. Tied or unfinished games are skipped (the underlying
+    fetch already filters to state="post"; tie scores would only arise
+    from rain-shortened games).
+    """
+    from datetime import datetime as _dt
+    from mlb.data import fetch_games_for_date
+
+    try:
+        target = _dt.strptime(date_str, "%Y-%m-%d").date()
+    except ValueError:
+        return pd.DataFrame(columns=_OUTCOMES_COLS)
+
+    games = fetch_games_for_date(target)
+    rows = []
+    for g in games:
+        if g.get("is_home") != 1:
+            continue
+        ts = g.get("team_score")
+        os_ = g.get("opp_score")
+        if ts is None or os_ is None or ts == os_:
+            continue
+        rows.append(
+            {
+                "date": date_str,
+                "home_team": g.get("team", ""),
+                "away_team": g.get("opponent", ""),
+                "game_time": g.get("game_time", ""),
+                "home_win": int(ts > os_),
+            }
+        )
+    return pd.DataFrame(rows, columns=_OUTCOMES_COLS)
+
+
 def parse_std_odds(value) -> Optional[int]:
     if value is None or pd.isna(value):
         return None
@@ -315,10 +355,35 @@ def grade(
     archive_dir: str = DEFAULT_ARCHIVE_DIR,
     processed_csv: str = DEFAULT_DATA_FILE,
     since: Optional[str] = None,
+    *,
+    fetch_live: bool = False,
 ) -> pd.DataFrame:
-    """Build the full shadow ledger by grading every eligible dated archive."""
+    """Build the full shadow ledger by grading every eligible dated archive.
+
+    Outcomes come from the training-data CSV. When fetch_live=True, any
+    archive date not covered by the CSV is filled in from the ESPN
+    scoreboard so the ledger stays up to date when the training-data
+    refresh has lagged. The library default is fetch_live=False so tests
+    and offline callers never hit the network; the CLI flips it on.
+    """
     archives = discover_archives(archive_dir, since)
     outcomes = load_outcomes(processed_csv)
+
+    if fetch_live and archives:
+        csv_dates = set(outcomes["date"].unique())
+        missing = sorted({date_iso for date_iso, _ in archives if date_iso not in csv_dates})
+        live_frames = []
+        for d in missing:
+            try:
+                live = fetch_outcomes_for_date(d)
+            except Exception as e:  # network errors, JSON shape changes
+                print(f"   warn: live outcome fetch failed for {d}: {e}", file=sys.stderr)
+                continue
+            if not live.empty:
+                live_frames.append(live)
+        if live_frames:
+            outcomes = pd.concat([outcomes, *live_frames], ignore_index=True)
+
     known_teams = set(outcomes["home_team"].unique()) | set(
         outcomes["away_team"].unique()
     )
@@ -426,9 +491,20 @@ def main() -> int:
     p.add_argument(
         "--no-report", action="store_true", help="Suppress aggregate report at end."
     )
+    p.add_argument(
+        "--no-live",
+        action="store_true",
+        help="Skip the ESPN scoreboard fallback for dates missing from the training CSV.",
+    )
     args = p.parse_args()
 
-    ledger = grade(args.archive_dir, args.data_file, args.since)
+    fetch_live = not args.no_live
+    ledger = grade(
+        args.archive_dir,
+        args.data_file,
+        args.since,
+        fetch_live=fetch_live,
+    )
     if not args.no_write:
         write_ledger(ledger, args.ledger)
         print(f"Wrote {len(ledger)} ledger rows to {args.ledger}")

--- a/tests/test_mlb_predict.py
+++ b/tests/test_mlb_predict.py
@@ -309,8 +309,9 @@ class TestRefreshShadowGraderLedger:
     def test_writes_ledger_on_success(self, monkeypatch, capsys):
         called = {}
 
-        def fake_grade():
+        def fake_grade(*args, **kwargs):
             called["grade"] = True
+            called["fetch_live"] = kwargs.get("fetch_live")
             return pd.DataFrame({"archive_date": ["2026-04-15"]})
 
         def fake_write(ledger, path=shadow_grader.DEFAULT_LEDGER):
@@ -321,11 +322,14 @@ class TestRefreshShadowGraderLedger:
 
         _refresh_shadow_grader_ledger()
         assert called.get("grade") is True
+        # The post-predict hook must opt into live-fetch so dashboards see
+        # actuals for archive dates the training CSV doesn't yet cover.
+        assert called.get("fetch_live") is True
         assert called.get("write") == (1, shadow_grader.DEFAULT_LEDGER)
         assert "Shadow grader" in capsys.readouterr().out
 
     def test_swallows_grader_exception(self, monkeypatch, capsys):
-        def boom():
+        def boom(*args, **kwargs):
             raise RuntimeError("training csv missing")
 
         monkeypatch.setattr(shadow_grader, "grade", boom)

--- a/tests/test_mlb_shadow_grader.py
+++ b/tests/test_mlb_shadow_grader.py
@@ -489,3 +489,113 @@ def test_aggregate_report_contains_paired_brier_deltas(tmp_path):
     formatted = shadow_grader.format_report(report)
     assert "Brier deltas" in formatted
     assert "Agreement" in formatted
+
+
+def test_fetch_outcomes_for_date_shapes_rows(monkeypatch):
+    """fetch_outcomes_for_date returns a DataFrame matching load_outcomes()."""
+    fake_games = [
+        {"date": "2026-05-08", "is_home": 1, "team": "Boston Red Sox",
+         "opponent": "Detroit Tigers", "team_score": 4, "opp_score": 2,
+         "game_time": "19:05"},
+        {"date": "2026-05-08", "is_home": 0, "team": "Detroit Tigers",
+         "opponent": "Boston Red Sox", "team_score": 2, "opp_score": 4,
+         "game_time": "19:05"},
+        # Tied (rain-shortened); should be skipped.
+        {"date": "2026-05-08", "is_home": 1, "team": "Texas Rangers",
+         "opponent": "Houston Astros", "team_score": 3, "opp_score": 3,
+         "game_time": "20:10"},
+    ]
+    monkeypatch.setattr(
+        "mlb.data.fetch_games_for_date", lambda _d: fake_games,
+    )
+    out = shadow_grader.fetch_outcomes_for_date("2026-05-08")
+    assert list(out.columns) == ["date", "home_team", "away_team", "game_time", "home_win"]
+    assert len(out) == 1
+    row = out.iloc[0]
+    assert row["home_team"] == "Boston Red Sox"
+    assert row["away_team"] == "Detroit Tigers"
+    assert row["home_win"] == 1
+
+
+def test_fetch_outcomes_for_date_invalid_date_returns_empty():
+    out = shadow_grader.fetch_outcomes_for_date("not-a-date")
+    assert out.empty
+
+
+def test_grade_fills_missing_dates_from_live_fetch(tmp_path, monkeypatch):
+    """Archive date absent from training CSV is filled in by fetch_live."""
+    rows = [_prediction_row(date="2026-05-02 19:05")]
+    archive = _write_archive(tmp_path, "2026-05-02", rows)
+    # Training CSV deliberately covers a different date so the join misses.
+    outcomes_csv = _write_outcomes(
+        tmp_path,
+        [{"date": "2026-04-15", "home": "New York Yankees",
+          "away": "Boston Red Sox", "home_won": True}],
+    )
+
+    fake_games = [
+        {"date": "2026-05-02", "is_home": 1, "team": "New York Yankees",
+         "opponent": "Boston Red Sox", "team_score": 6, "opp_score": 3,
+         "game_time": "19:05"},
+        {"date": "2026-05-02", "is_home": 0, "team": "Boston Red Sox",
+         "opponent": "New York Yankees", "team_score": 3, "opp_score": 6,
+         "game_time": "19:05"},
+    ]
+    monkeypatch.setattr(
+        "mlb.data.fetch_games_for_date", lambda _d: fake_games,
+    )
+
+    ledger = shadow_grader.grade(
+        os.path.dirname(archive), outcomes_csv, fetch_live=True,
+    )
+
+    assert len(ledger) == 1
+    row = ledger.iloc[0]
+    assert row["outcome_status"] == "graded"
+    assert row["home_won"] == 1
+    assert row["production_correct"]
+
+
+def test_grade_fetch_live_disabled_leaves_row_pending(tmp_path, monkeypatch):
+    """fetch_live=False (the library default) must not call the network."""
+    rows = [_prediction_row(date="2026-05-02 19:05")]
+    archive = _write_archive(tmp_path, "2026-05-02", rows)
+    outcomes_csv = _write_outcomes(
+        tmp_path,
+        [{"date": "2026-04-15", "home": "New York Yankees",
+          "away": "Boston Red Sox", "home_won": True}],
+    )
+
+    def _boom(_d):
+        raise AssertionError("fetch_games_for_date must not be called when fetch_live=False")
+
+    monkeypatch.setattr("mlb.data.fetch_games_for_date", _boom)
+
+    ledger = shadow_grader.grade(os.path.dirname(archive), outcomes_csv)
+    assert len(ledger) == 1
+    assert ledger.iloc[0]["outcome_status"] == "outcome_pending"
+
+
+def test_grade_live_fetch_failure_keeps_row_pending(tmp_path, monkeypatch, capsys):
+    """A live-fetch exception is logged but does not abort the run."""
+    rows = [_prediction_row(date="2026-05-02 19:05")]
+    archive = _write_archive(tmp_path, "2026-05-02", rows)
+    outcomes_csv = _write_outcomes(
+        tmp_path,
+        [{"date": "2026-04-15", "home": "New York Yankees",
+          "away": "Boston Red Sox", "home_won": True}],
+    )
+
+    def _raise(_d):
+        raise RuntimeError("network is down")
+
+    monkeypatch.setattr("mlb.data.fetch_games_for_date", _raise)
+
+    ledger = shadow_grader.grade(
+        os.path.dirname(archive), outcomes_csv, fetch_live=True,
+    )
+
+    assert len(ledger) == 1
+    assert ledger.iloc[0]["outcome_status"] == "outcome_pending"
+    err = capsys.readouterr().err
+    assert "live outcome fetch failed" in err


### PR DESCRIPTION
## Summary
The MLB shadow grader has been silently dark since 5/2 because it grades against `data/mlb_training_data_processed.csv` and that file's most recent outcome is 2026-04-02. Every May archive falls through to `outcome_pending` and the dashboard sees no actuals (Brier / accuracy / ROI all NaN).

This PR keeps the CSV as the primary outcome source and adds an ESPN-scoreboard fallback for any archive date the CSV doesn't cover. Concretely:

- New `fetch_outcomes_for_date(date_str)` returns the same shape as `load_outcomes()` but for a single date, sourced from `mlb.data.fetch_games_for_date` (already used elsewhere in the repo).
- `grade(..., fetch_live=False)` is the library default so tests and offline callers never hit the network.
- The CLI defaults `fetch_live=True` (opt-out via `--no-live`) so the nightly grader stays current.
- Live-fetch failures are logged and skipped without aborting the run.

Live dry-run against the May archives: **74 of 81 rows now grade** (was 0/81 before this change).

```
Shadow grader: 74 graded games (total 81, ROI eligible 62, missing 12)
  Brier mean: production=0.2481  shadow=0.2506  market=0.2466
  Accuracy:  production=0.541   shadow=0.568   market=0.568
  ROI (units): production=-2.18 shadow=+1.24  market=+1.15
```

The remaining 7 ungraded rows are likely team-name normalization edge cases / doubleheaders / postponed games -- not in scope for this PR.

## Test plan
- [x] `uv run --extra test pytest -q` -- 787 passed
- [x] New tests:
  - `test_fetch_outcomes_for_date_shapes_rows` (mocked, including tied-game skip)
  - `test_fetch_outcomes_for_date_invalid_date_returns_empty`
  - `test_grade_fills_missing_dates_from_live_fetch`
  - `test_grade_fetch_live_disabled_leaves_row_pending` (asserts no network call when off)
  - `test_grade_live_fetch_failure_keeps_row_pending` (network error -> graceful)
- [x] Live dry-run via `python -m mlb.shadow_grader --since 2026-05-01 --no-write` confirms the CSV gap is filled
- [ ] After merge: run the grader to overwrite `data/mlb_shadow_grader_ledger.csv`, verify dashboard surfaces the new graded rows

## Out of scope
- Refreshing `mlb_training_data_processed.csv` itself (still useful for offline backfills; just no longer load-bearing for the live grader)
- Improving team-name normalization for the residual 7 ungraded May rows