### PR TITLE
Dashboard: pull rich MLB candidate view up to MLB Today

### DIFF
--- a/app.py
+++ b/app.py
@@ -1495,7 +1495,9 @@ if _leagues_to_run:
     finally:
         sys.stdout = saved_stdout
 
-    _render_panel(running=False)
+    # Loading complete; the freshness banner below already shows the
+    # generated-at timestamp, so the live panel goes away to reduce noise.
+    panel.empty()
 
 # Build league_data from prediction CSVs
 for lg in LEAGUES:

--- a/app.py
+++ b/app.py
@@ -1254,7 +1254,11 @@ def _render_freshness_banner():
 
 
 def _render_mlb_today_panel():
-    """Primary decision surface: only token-bet confluence rows for MLB."""
+    """Primary decision surface: MLB token-bet candidates with full context.
+
+    Brings the candidate summary + SP-aware candidate table up to the top of
+    the page so the user doesn't have to scroll to the bottom Full Slates tab.
+    """
     st.markdown(
         '<div class="section-title" id="mlb-today">MLB Today</div>',
         unsafe_allow_html=True,
@@ -1271,13 +1275,24 @@ def _render_mlb_today_panel():
     candidates = token_bet_candidate_mask(game_df)
     n = int(candidates.sum())
     if n == 0:
-        st.caption(
-            "No token-bet candidates today (Std_Rating GOOD/STRONG, "
-            "shadow ok, agrees with production, edge > 0)."
-        )
+        st.caption("No token-bet candidates today.")
         return
 
     cand_df = game_df[candidates].copy()
+
+    # Bulleted summary lines for the callout (one row per candidate).
+    summary_lines = [
+        f"- **{r.get('Matchup', '')}** -- pick **{r.get('Pick', '')}** "
+        f"@ `{r.get('Std_Odds', '?')}`, prod conf "
+        f"{float(r.get('Conf') or 0):.1%}, shadow edge "
+        f"{float(r.get('MarketV2_Edge_vs_Market') or 0):+.1%}"
+        for _, r in cand_df.iterrows()
+    ]
+    st.success(
+        f"**{n} token-bet candidate(s)** on today's slate:\n\n"
+        + "\n".join(summary_lines)
+    )
+
     if "Std_Units" in cand_df.columns:
         cand_df["Pilot Stake"] = cand_df["Std_Units"].apply(
             lambda x: f"{pilot_stake_units(x):.2f}U"
@@ -1296,23 +1311,21 @@ def _render_mlb_today_panel():
     if "Rating" in cand_df.columns:
         cand_df = cand_df.drop(columns=["Rating"])
     cand_df = cand_df.rename(columns={
+        "Pick": "Prod Pick",
         "Std_Odds": "Odds",
         "Std_Rating": "Rating",
-        "Std_Units": "Model Units",
     })
 
     show_cols = [
-        "Date/Time", "Matchup", "Pick", "Odds", "Prod Conf",
-        "Shadow Edge", "Rating", "Model Units", "Pilot Stake",
+        "Date/Time", "Matchup", "Home_SP", "Away_SP",
+        "Prod Pick", "Odds", "Prod Conf", "Shadow Edge",
+        "Rating", "Pilot Stake",
     ]
     show_cols = [c for c in show_cols if c in cand_df.columns]
-
-    st.success(f"{n} token-bet candidate(s) on today's slate.")
-    st.caption(
-        "Manual checks before placing: live odds at or near the archived "
-        "Odds, and no stale lineup or pitcher info."
-    )
     st.dataframe(cand_df[show_cols], use_container_width=True, hide_index=True)
+    st.caption(
+        "Verify before placing: live odds near archived; no stale lineup or pitcher."
+    )
 
 
 def _render_shadow_grader_panel():
@@ -2051,26 +2064,10 @@ def _render_mlb_slate(game_df, lg):
         st.caption("No matching picks.")
         return
 
-    # Token-bet confluence flag computed from raw columns before any rename.
+    # Token-bet confluence flag for sorting/highlighting. The verbose
+    # candidate summary lives in the MLB Today panel at the top of the page;
+    # the Full Slates tab is the diagnostic dataframe with all picks visible.
     candidates = token_bet_candidate_mask(display_df)
-    n_candidates = int(candidates.sum())
-    if n_candidates > 0:
-        lines = [
-            f"- **{r.get('Matchup', '')}** -- pick **{r.get('Pick', '')}** "
-            f"@ `{r.get('Std_Odds', '?')}`, prod conf "
-            f"{float(r.get('Conf') or 0):.1%}, shadow edge "
-            f"{float(r.get('MarketV2_Edge_vs_Market') or 0):+.1%}, "
-            f"DK rating {r.get('Std_Rating', '?')}"
-            for _, r in display_df[candidates].iterrows()
-        ]
-        st.success(
-            f"**{n_candidates} token-bet candidate(s)** "
-            "(Std_Rating GOOD/STRONG, shadow ok, shadow agrees with "
-            "production, shadow edge > 0):\n\n"
-            + "\n".join(lines)
-            + "\n\n_Still verify manually before betting:_ live odds near "
-            "the archived Std_Odds, and no stale lineup/pitcher."
-        )
     display_df["Bet?"] = candidates.map(lambda x: "yes" if x else "")
 
     # Production-model display columns

--- a/app.py
+++ b/app.py
@@ -12,7 +12,12 @@ import io
 import sys
 import threading
 from contextlib import redirect_stdout
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import (
+    FIRST_COMPLETED,
+    ThreadPoolExecutor,
+    as_completed,
+    wait,
+)
 from datetime import datetime, timedelta, timezone
 import pytz
 import csv
@@ -1251,21 +1256,68 @@ def _build_live_positions(positions, live_games) -> list[dict]:
 # ==========================================
 league_data = {}
 
-# Per-thread stdout splitter: each worker thread sets _THREAD_BUFFERS.buf to
-# a StringIO before running its prediction pipeline; print() calls in that
-# thread go to the buffer (and to the original stdout so terminal logs still
-# work). Main-thread writes pass through unchanged.
+# Per-thread stdout splitter: each worker sets _THREAD_BUFFERS.stream to its
+# own _CapturedStream before running its prediction pipeline; print() calls
+# in that thread go to that stream (which also forwards to the real stdout
+# so terminal logs still work). The main thread polls the captured streams
+# between wait() calls to surface live progress in the loading panel.
 _THREAD_BUFFERS = threading.local()
 
 
+class _CapturedStream:
+    """Thread-safe line-buffered stream for one worker's stdout.
+
+    `write()` is called from a single worker thread; `consume_new()` is
+    called from the main thread between waits. Lines are only finalized
+    when `\\n` is seen, so the activity preview never shows a half-flushed
+    line.
+    """
+
+    def __init__(self, fallback):
+        self._fallback = fallback
+        self._lock = threading.Lock()
+        self._lines: list[str] = []
+        self._partial = ""
+
+    def write(self, s: str) -> int:
+        if not s:
+            return 0
+        self._fallback.write(s)
+        with self._lock:
+            self._partial += s
+            if "\n" in self._partial:
+                parts = self._partial.split("\n")
+                self._partial = parts[-1]
+                for line in parts[:-1]:
+                    stripped = line.strip()
+                    if stripped:
+                        self._lines.append(stripped)
+        return len(s)
+
+    def flush(self):
+        self._fallback.flush()
+
+    def isatty(self):
+        return False
+
+    def consume_new(self, offset: int) -> tuple[list[str], int]:
+        """Return new lines since `offset` and the new offset to remember."""
+        with self._lock:
+            return list(self._lines[offset:]), len(self._lines)
+
+
 class _ThreadDispatchStdout:
+    """Routes a worker thread's writes to its _CapturedStream; main-thread
+    writes (and writes from threads with no captured stream) pass through to
+    the original stdout."""
+
     def __init__(self, fallback):
         self._fallback = fallback
 
     def write(self, s):
-        buf = getattr(_THREAD_BUFFERS, "buf", None)
-        if buf is not None:
-            buf.write(s)
+        stream = getattr(_THREAD_BUFFERS, "stream", None)
+        if stream is not None:
+            return stream.write(s)
         return self._fallback.write(s)
 
     def flush(self):
@@ -1275,13 +1327,14 @@ class _ThreadDispatchStdout:
         return False
 
 
-def _run_predictions(lg, spread_overrides=None):
+def _run_predictions(lg, stream, spread_overrides=None):
     """Run prediction pipeline for a single league. Thread-safe.
 
-    Captures the pipeline's stdout into a per-thread buffer so the dashboard
-    can stream the script's actual progress log instead of a blank spinner.
+    Sets a thread-local capture target so the prediction script's stdout is
+    streamed live into the loading panel instead of waiting for the future
+    to resolve.
     """
-    _THREAD_BUFFERS.buf = io.StringIO()
+    _THREAD_BUFFERS.stream = stream
     try:
         if lg == "mlb":
             mlb_predict.generate_predictions(lg)
@@ -1290,9 +1343,8 @@ def _run_predictions(lg, spread_overrides=None):
                 spread_overrides=spread_overrides or {},
                 league=lg,
             )
-        return _THREAD_BUFFERS.buf.getvalue()
     finally:
-        _THREAD_BUFFERS.buf = None
+        _THREAD_BUFFERS.stream = None
 
 
 # Determine which leagues need a prediction run
@@ -1384,39 +1436,59 @@ if _leagues_to_run:
 
     saved_stdout = sys.stdout
     sys.stdout = _ThreadDispatchStdout(saved_stdout)
+    streams: dict[str, _CapturedStream] = {
+        lg: _CapturedStream(saved_stdout) for lg in _leagues_to_run
+    }
+    offsets: dict[str, int] = {lg: 0 for lg in _leagues_to_run}
+
+    def _drain(lg: str) -> None:
+        new_lines, new_offset = streams[lg].consume_new(offsets[lg])
+        offsets[lg] = new_offset
+        for line in new_lines:
+            _add_log(lg, lg, line)
+            activities[lg] = line
+
     try:
         _errors = {}
         with ThreadPoolExecutor(max_workers=len(_leagues_to_run)) as executor:
             futures = {
-                executor.submit(_run_predictions, lg, _spread_overrides[lg]): lg
+                executor.submit(_run_predictions, lg, streams[lg], _spread_overrides[lg]): lg
                 for lg in _leagues_to_run
             }
             for lg in _leagues_to_run:
                 statuses[lg] = "running"
-                activities[lg] = "running pipeline"
+                activities[lg] = "starting"
             _render_panel()
 
-            for future in as_completed(futures):
-                lg = futures[future]
-                pred_file = _league_artifacts[lg]["paths"]["predictions_file"]
-                try:
-                    captured = future.result() or ""
-                    if os.path.exists(pred_file):
-                        st.session_state[f"predictions_loaded_{lg}"] = True
-                    last = ""
-                    for raw in captured.splitlines():
-                        line = raw.strip()
-                        if line:
-                            _add_log(lg, lg, line)
-                            last = line
-                    statuses[lg] = "done"
-                    activities[lg] = last or "done"
-                    _add_log(lg, lg, "done", line_class="done")
-                except Exception as e:
-                    _errors[lg] = e
-                    statuses[lg] = "failed"
-                    activities[lg] = f"failed: {e}"
-                    _add_log(lg, lg, f"FAILED: {e}", line_class="failed")
+            pending = set(futures.keys())
+            while pending:
+                done, pending = wait(
+                    pending, timeout=0.4, return_when=FIRST_COMPLETED
+                )
+                # Tail every running league's buffer first so the panel
+                # reflects any in-flight progress before flipping a future
+                # to done.
+                for f, lg in futures.items():
+                    if statuses[lg] == "running":
+                        _drain(lg)
+
+                for future in done:
+                    lg = futures[future]
+                    pred_file = _league_artifacts[lg]["paths"]["predictions_file"]
+                    try:
+                        future.result()
+                        _drain(lg)
+                        if os.path.exists(pred_file):
+                            st.session_state[f"predictions_loaded_{lg}"] = True
+                        statuses[lg] = "done"
+                        _add_log(lg, lg, "done", line_class="done")
+                        if not activities[lg] or activities[lg] in ("starting", "running pipeline"):
+                            activities[lg] = "done"
+                    except Exception as e:
+                        _errors[lg] = e
+                        statuses[lg] = "failed"
+                        activities[lg] = f"failed: {e}"
+                        _add_log(lg, lg, f"FAILED: {e}", line_class="failed")
                 _render_panel()
         for lg, e in _errors.items():
             st.error(f"Failed to load {get_league_settings(lg)['label']} predictions: {e}")

--- a/app.py
+++ b/app.py
@@ -8,12 +8,9 @@ import html as html_mod
 import predict
 import backtest
 import mlb.predict as mlb_predict
-import io
-from contextlib import redirect_stdout
 from concurrent.futures import (
     FIRST_COMPLETED,
     ThreadPoolExecutor,
-    as_completed,
     wait,
 )
 from datetime import datetime, timedelta, timezone
@@ -31,6 +28,7 @@ from dashboard_helpers import (
     install_stdout_dispatcher,
     pilot_stake_units,
     position_matches_game,
+    silenced_stdout,
     token_bet_candidate_mask,
     utc_date_to_eastern,
 )
@@ -2415,9 +2413,13 @@ with col_perf:
                 st.caption("No performance data yet.")
                 if st.button("Run Backtest", key=f"backtest_{lg}"):
                     with st.spinner("Training models..."):
-                        f = io.StringIO()
                         try:
-                            with redirect_stdout(f):
+                            # silenced_stdout() routes only this thread's
+                            # stdout through the dispatcher's thread-local
+                            # hook, so a concurrent prediction refresh in
+                            # another session still captures its workers'
+                            # output correctly.
+                            with silenced_stdout():
                                 backtest.run_backtest(league=lg)
                             if os.path.exists(perf_file):
                                 st.success("Done!")

--- a/app.py
+++ b/app.py
@@ -9,8 +9,6 @@ import predict
 import backtest
 import mlb.predict as mlb_predict
 import io
-import sys
-import threading
 from contextlib import redirect_stdout
 from concurrent.futures import (
     FIRST_COMPLETED,
@@ -27,7 +25,10 @@ from betting import format_line_shopping_text, VALUE_RATINGS, RATING_RANK
 from league_config import get_league_artifact_paths, get_league_settings, get_scoreboard_base_url, normalize_league
 from prediction_io import load_predictions_csv
 from dashboard_helpers import (
+    CapturedStream,
+    THREAD_BUFFERS,
     filter_recent_kalshi,
+    install_stdout_dispatcher,
     pilot_stake_units,
     position_matches_game,
     token_bet_candidate_mask,
@@ -1256,75 +1257,11 @@ def _build_live_positions(positions, live_games) -> list[dict]:
 # ==========================================
 league_data = {}
 
-# Per-thread stdout splitter: each worker sets _THREAD_BUFFERS.stream to its
-# own _CapturedStream before running its prediction pipeline; print() calls
-# in that thread go to that stream (which also forwards to the real stdout
-# so terminal logs still work). The main thread polls the captured streams
-# between wait() calls to surface live progress in the loading panel.
-_THREAD_BUFFERS = threading.local()
-
-
-class _CapturedStream:
-    """Thread-safe line-buffered stream for one worker's stdout.
-
-    `write()` is called from a single worker thread; `consume_new()` is
-    called from the main thread between waits. Lines are only finalized
-    when `\\n` is seen, so the activity preview never shows a half-flushed
-    line.
-    """
-
-    def __init__(self, fallback):
-        self._fallback = fallback
-        self._lock = threading.Lock()
-        self._lines: list[str] = []
-        self._partial = ""
-
-    def write(self, s: str) -> int:
-        if not s:
-            return 0
-        self._fallback.write(s)
-        with self._lock:
-            self._partial += s
-            if "\n" in self._partial:
-                parts = self._partial.split("\n")
-                self._partial = parts[-1]
-                for line in parts[:-1]:
-                    stripped = line.strip()
-                    if stripped:
-                        self._lines.append(stripped)
-        return len(s)
-
-    def flush(self):
-        self._fallback.flush()
-
-    def isatty(self):
-        return False
-
-    def consume_new(self, offset: int) -> tuple[list[str], int]:
-        """Return new lines since `offset` and the new offset to remember."""
-        with self._lock:
-            return list(self._lines[offset:]), len(self._lines)
-
-
-class _ThreadDispatchStdout:
-    """Routes a worker thread's writes to its _CapturedStream; main-thread
-    writes (and writes from threads with no captured stream) pass through to
-    the original stdout."""
-
-    def __init__(self, fallback):
-        self._fallback = fallback
-
-    def write(self, s):
-        stream = getattr(_THREAD_BUFFERS, "stream", None)
-        if stream is not None:
-            return stream.write(s)
-        return self._fallback.write(s)
-
-    def flush(self):
-        self._fallback.flush()
-
-    def isatty(self):
-        return False
+# See dashboard_helpers.CapturedStream / ThreadDispatchStdout for details:
+# the dispatcher is installed once per process and always defers to
+# sys.__stdout__, so overlapping Streamlit sessions can't chain dispatchers
+# into a recursive fallback loop.
+install_stdout_dispatcher()
 
 
 def _run_predictions(lg, stream, spread_overrides=None):
@@ -1334,7 +1271,7 @@ def _run_predictions(lg, stream, spread_overrides=None):
     streamed live into the loading panel instead of waiting for the future
     to resolve.
     """
-    _THREAD_BUFFERS.stream = stream
+    THREAD_BUFFERS.stream = stream
     try:
         if lg == "mlb":
             mlb_predict.generate_predictions(lg)
@@ -1344,7 +1281,7 @@ def _run_predictions(lg, stream, spread_overrides=None):
                 league=lg,
             )
     finally:
-        _THREAD_BUFFERS.stream = None
+        THREAD_BUFFERS.stream = None
 
 
 # Determine which leagues need a prediction run
@@ -1434,10 +1371,12 @@ if _leagues_to_run:
     _add_log("system", "system", "Sources: ESPN schedules, Kalshi, Polymarket")
     _render_panel()
 
-    saved_stdout = sys.stdout
-    sys.stdout = _ThreadDispatchStdout(saved_stdout)
-    streams: dict[str, _CapturedStream] = {
-        lg: _CapturedStream(saved_stdout) for lg in _leagues_to_run
+    # The dispatcher is installed at module load; we just need to register
+    # a capture stream per worker via thread-local state inside
+    # _run_predictions. Main-thread writes still pass through to the real
+    # stdout because THREAD_BUFFERS.stream is unset on this thread.
+    streams: dict[str, CapturedStream] = {
+        lg: CapturedStream() for lg in _leagues_to_run
     }
     offsets: dict[str, int] = {lg: 0 for lg in _leagues_to_run}
 
@@ -1448,52 +1387,49 @@ if _leagues_to_run:
             _add_log(lg, lg, line)
             activities[lg] = line
 
-    try:
-        _errors = {}
-        with ThreadPoolExecutor(max_workers=len(_leagues_to_run)) as executor:
-            futures = {
-                executor.submit(_run_predictions, lg, streams[lg], _spread_overrides[lg]): lg
-                for lg in _leagues_to_run
-            }
-            for lg in _leagues_to_run:
-                statuses[lg] = "running"
-                activities[lg] = "starting"
+    _errors = {}
+    with ThreadPoolExecutor(max_workers=len(_leagues_to_run)) as executor:
+        futures = {
+            executor.submit(_run_predictions, lg, streams[lg], _spread_overrides[lg]): lg
+            for lg in _leagues_to_run
+        }
+        for lg in _leagues_to_run:
+            statuses[lg] = "running"
+            activities[lg] = "starting"
+        _render_panel()
+
+        pending = set(futures.keys())
+        while pending:
+            done, pending = wait(
+                pending, timeout=0.4, return_when=FIRST_COMPLETED
+            )
+            # Tail every running league's buffer first so the panel
+            # reflects any in-flight progress before flipping a future
+            # to done.
+            for f, lg in futures.items():
+                if statuses[lg] == "running":
+                    _drain(lg)
+
+            for future in done:
+                lg = futures[future]
+                pred_file = _league_artifacts[lg]["paths"]["predictions_file"]
+                try:
+                    future.result()
+                    _drain(lg)
+                    if os.path.exists(pred_file):
+                        st.session_state[f"predictions_loaded_{lg}"] = True
+                    statuses[lg] = "done"
+                    _add_log(lg, lg, "done", line_class="done")
+                    if not activities[lg] or activities[lg] in ("starting", "running pipeline"):
+                        activities[lg] = "done"
+                except Exception as e:
+                    _errors[lg] = e
+                    statuses[lg] = "failed"
+                    activities[lg] = f"failed: {e}"
+                    _add_log(lg, lg, f"FAILED: {e}", line_class="failed")
             _render_panel()
-
-            pending = set(futures.keys())
-            while pending:
-                done, pending = wait(
-                    pending, timeout=0.4, return_when=FIRST_COMPLETED
-                )
-                # Tail every running league's buffer first so the panel
-                # reflects any in-flight progress before flipping a future
-                # to done.
-                for f, lg in futures.items():
-                    if statuses[lg] == "running":
-                        _drain(lg)
-
-                for future in done:
-                    lg = futures[future]
-                    pred_file = _league_artifacts[lg]["paths"]["predictions_file"]
-                    try:
-                        future.result()
-                        _drain(lg)
-                        if os.path.exists(pred_file):
-                            st.session_state[f"predictions_loaded_{lg}"] = True
-                        statuses[lg] = "done"
-                        _add_log(lg, lg, "done", line_class="done")
-                        if not activities[lg] or activities[lg] in ("starting", "running pipeline"):
-                            activities[lg] = "done"
-                    except Exception as e:
-                        _errors[lg] = e
-                        statuses[lg] = "failed"
-                        activities[lg] = f"failed: {e}"
-                        _add_log(lg, lg, f"FAILED: {e}", line_class="failed")
-                _render_panel()
-        for lg, e in _errors.items():
-            st.error(f"Failed to load {get_league_settings(lg)['label']} predictions: {e}")
-    finally:
-        sys.stdout = saved_stdout
+    for lg, e in _errors.items():
+        st.error(f"Failed to load {get_league_settings(lg)['label']} predictions: {e}")
 
     # Loading complete; the freshness banner below already shows the
     # generated-at timestamp, so the live panel goes away to reduce noise.

--- a/app.py
+++ b/app.py
@@ -461,6 +461,43 @@ p, span, div, .stMarkdown {
     color: var(--neutral-400);
 }
 
+/* MLB Today extras: stake pill (the only high-contrast block per card so
+   the eye lands on stake size first) and pitcher subtitle. */
+.stake-pill {
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    font-weight: 600;
+    background: var(--neutral-900);
+    color: #ffffff;
+    padding: 3px 10px;
+    border-radius: 4px;
+    letter-spacing: 0.02em;
+    margin-left: 8px;
+}
+.pitcher-line {
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    color: var(--neutral-400);
+    margin: 2px 0 6px;
+}
+.bet-pick-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+}
+.bet-pick-row .bet-odds {
+    font-family: var(--font-mono);
+    font-size: 1.0rem;
+    font-weight: 500;
+    color: var(--neutral-900);
+}
+.mlb-today-summary {
+    font-family: var(--font-body);
+    color: var(--neutral-500);
+    font-size: 0.85rem;
+    margin: 0.5rem 0 0.75rem;
+}
+
 /* Refresh button (main area) */
 .main .stButton > button {
     font-family: var(--font-body);
@@ -1280,49 +1317,99 @@ def _render_mlb_today_panel():
 
     cand_df = game_df[candidates].copy()
 
-    # Bulleted summary lines for the callout (one row per candidate).
-    summary_lines = [
-        f"- **{r.get('Matchup', '')}** -- pick **{r.get('Pick', '')}** "
-        f"@ `{r.get('Std_Odds', '?')}`, prod conf "
-        f"{float(r.get('Conf') or 0):.1%}, shadow edge "
-        f"{float(r.get('MarketV2_Edge_vs_Market') or 0):+.1%}"
-        for _, r in cand_df.iterrows()
-    ]
-    st.success(
-        f"**{n} token-bet candidate(s)** on today's slate:\n\n"
-        + "\n".join(summary_lines)
+    total_stake = sum(
+        pilot_stake_units(r.get("Std_Units")) for _, r in cand_df.iterrows()
+    )
+    st.markdown(
+        f'<div class="mlb-today-summary">{n} candidate'
+        f'{"" if n == 1 else "s"} &middot; {total_stake:.2f}U total</div>',
+        unsafe_allow_html=True,
     )
 
-    if "Std_Units" in cand_df.columns:
-        cand_df["Pilot Stake"] = cand_df["Std_Units"].apply(
-            lambda x: f"{pilot_stake_units(x):.2f}U"
-        )
-    if "Conf" in cand_df.columns:
-        cand_df["Prod Conf"] = cand_df["Conf"].apply(
-            lambda x: f"{float(x):.1%}" if pd.notna(x) else ""
-        )
-    if "MarketV2_Edge_vs_Market" in cand_df.columns:
-        cand_df["Shadow Edge"] = cand_df["MarketV2_Edge_vs_Market"].apply(
-            lambda x: f"{float(x):+.1%}" if pd.notna(x) else ""
-        )
-    # Drop the Kalshi-side "Rating" column before renaming Std_Rating so the
-    # rename doesn't create a duplicate column name. MLB Today shows only DK
-    # rating (the gate that already qualified the row).
-    if "Rating" in cand_df.columns:
-        cand_df = cand_df.drop(columns=["Rating"])
-    cand_df = cand_df.rename(columns={
-        "Pick": "Prod Pick",
-        "Std_Odds": "Odds",
-        "Std_Rating": "Rating",
-    })
+    for _, r in cand_df.iterrows():
+        rating = str(r.get("Std_Rating", "") or "").upper()
+        rating_class = rating.lower() if rating in ("STRONG", "GOOD") else "good"
 
-    show_cols = [
-        "Date/Time", "Matchup", "Home_SP", "Away_SP",
-        "Prod Pick", "Odds", "Prod Conf", "Shadow Edge",
-        "Rating", "Pilot Stake",
-    ]
-    show_cols = [c for c in show_cols if c in cand_df.columns]
-    st.dataframe(cand_df[show_cols], use_container_width=True, hide_index=True)
+        stake = pilot_stake_units(r.get("Std_Units"))
+        stake_str = f"{stake:.2f}U"
+
+        pick = str(r.get("Pick", "") or "")
+        matchup = str(r.get("Matchup", "") or "")
+        opponent = ""
+        if " @ " in matchup:
+            away, home = matchup.split(" @ ", 1)
+            opponent = away if pick.strip() == home.strip() else home
+
+        odds_raw = r.get("Std_Odds", "")
+        try:
+            odds_int = int(float(odds_raw))
+            odds_str = f"{odds_int:+d}"
+        except (TypeError, ValueError):
+            odds_str = str(odds_raw) if odds_raw not in (None, "") else ""
+
+        conf_val = r.get("Conf")
+        try:
+            conf_str = f"{float(conf_val):.1%}" if pd.notna(conf_val) else ""
+        except (TypeError, ValueError):
+            conf_str = ""
+
+        edge_val = r.get("MarketV2_Edge_vs_Market")
+        try:
+            edge_str = f"{float(edge_val):+.1%}" if pd.notna(edge_val) else ""
+        except (TypeError, ValueError):
+            edge_str = ""
+
+        home_sp = str(r.get("Home_SP", "") or "").strip()
+        away_sp = str(r.get("Away_SP", "") or "").strip()
+        if home_sp and away_sp:
+            pitcher_line = f"SP: {away_sp} @ {home_sp}"
+        elif home_sp or away_sp:
+            pitcher_line = f"SP: {home_sp or away_sp}"
+        else:
+            pitcher_line = ""
+
+        game_time = str(r.get("Date/Time", "") or "")
+
+        opponent_html = (
+            f'<div class="bet-matchup">vs {_esc(opponent)}</div>'
+            if opponent
+            else ""
+        )
+        pitcher_html = (
+            f'<div class="pitcher-line">{_esc(pitcher_line)}</div>'
+            if pitcher_line
+            else ""
+        )
+
+        card_html = f"""
+        <div class="bet-card {rating_class}">
+            <div class="bet-header">
+                <div><span class="bet-badge {rating_class}">{_esc(rating)}</span></div>
+                <div>
+                    <span class="bet-time">{_esc(game_time)}</span>
+                    <span class="stake-pill">{_esc(stake_str)}</span>
+                </div>
+            </div>
+            <div class="bet-pick-row">
+                <div class="bet-pick">{_esc(pick)} ML</div>
+                <div class="bet-odds">{_esc(odds_str)}</div>
+            </div>
+            {opponent_html}
+            {pitcher_html}
+            <div class="bet-stats">
+                <div class="stat-item">
+                    <span class="stat-label">Prod Conf</span>
+                    <span class="stat-value">{_esc(conf_str)}</span>
+                </div>
+                <div class="stat-item">
+                    <span class="stat-label">Shadow Edge</span>
+                    <span class="stat-value positive">{_esc(edge_str)}</span>
+                </div>
+            </div>
+        </div>
+        """
+        st.markdown(card_html, unsafe_allow_html=True)
+
     st.caption(
         "Verify before placing: live odds near archived; no stale lineup or pitcher."
     )

--- a/app.py
+++ b/app.py
@@ -9,6 +9,8 @@ import predict
 import backtest
 import mlb.predict as mlb_predict
 import io
+import sys
+import threading
 from contextlib import redirect_stdout
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta, timezone
@@ -497,6 +499,181 @@ p, span, div, .stMarkdown {
     font-size: 0.85rem;
     margin: 0.5rem 0 0.75rem;
 }
+
+/* Live loading panel: light, Vercel-style build-log idiom. Per-league rows
+   with a spinner -> check transition, a thin animated progress rail, and a
+   collapsible full log. Replaces a generic "Loading..." spinner. */
+.loading-panel {
+    background: var(--neutral-50);
+    border: 1px solid var(--neutral-100);
+    border-radius: 12px;
+    padding: 16px 20px 14px;
+    margin: 0.5rem 0 1rem;
+    box-shadow: 0 1px 3px rgba(20,40,30,0.04), 0 6px 20px rgba(20,40,30,0.05);
+    font-family: var(--font-body);
+}
+.loading-panel .panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 12px;
+}
+.loading-panel .panel-title {
+    font-weight: 700;
+    color: var(--neutral-900);
+    font-size: 0.92rem;
+    letter-spacing: -0.01em;
+}
+.loading-panel .panel-meta {
+    font-family: var(--font-mono);
+    font-size: 0.66rem;
+    color: var(--neutral-400);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+.loading-panel .progress-rail {
+    height: 3px;
+    background: var(--neutral-100);
+    border-radius: 2px;
+    overflow: hidden;
+    margin-bottom: 12px;
+    position: relative;
+}
+.loading-panel .progress-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 35%;
+    background: linear-gradient(90deg,
+        var(--green-700) 0%, var(--green-600) 55%, var(--gold-600) 100%);
+    border-radius: 2px;
+    animation: rail-slide 1.4s ease-in-out infinite;
+}
+@keyframes rail-slide {
+    0% { left: -35%; }
+    100% { left: 100%; }
+}
+.loading-panel.complete .progress-fill {
+    left: 0;
+    width: 100%;
+    animation: none;
+    background: var(--green-700);
+}
+.lg-row {
+    display: grid;
+    grid-template-columns: 22px 88px 78px 1fr;
+    gap: 12px;
+    align-items: center;
+    padding: 7px 0;
+    border-top: 1px solid rgba(20,40,30,0.04);
+}
+.lg-row:first-of-type { border-top: 0; }
+.lg-icon { display: inline-flex; align-items: center; justify-content: center; }
+.lg-icon.running::after, .lg-icon.queued::after {
+    content: "";
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    border: 2px solid var(--neutral-200);
+    border-top-color: var(--green-700);
+    animation: spin 0.9s linear infinite;
+}
+.lg-icon.queued::after { border-top-color: var(--neutral-400); animation-duration: 1.6s; }
+@keyframes spin { to { transform: rotate(360deg); } }
+.lg-icon.done {
+    color: var(--green-700); font-weight: 700; font-size: 0.85rem;
+    font-family: var(--font-mono);
+}
+.lg-icon.failed {
+    color: #b3463a; font-weight: 700; font-size: 0.85rem;
+    font-family: var(--font-mono);
+}
+.lg-tag {
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    padding: 3px 9px;
+    border-radius: 4px;
+    color: #ffffff;
+    text-align: center;
+}
+.lg-tag.mlb { background: var(--gold-600); }
+.lg-tag.mens { background: #3b6bb5; }
+.lg-tag.womens { background: var(--purple-700); }
+.lg-status {
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    color: var(--neutral-500);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+}
+.lg-status.done { color: var(--green-700); }
+.lg-status.failed { color: #b3463a; }
+.lg-activity {
+    font-family: var(--font-mono);
+    font-size: 0.74rem;
+    color: var(--neutral-500);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.loading-panel .log-detail {
+    margin-top: 12px;
+    padding-top: 10px;
+    border-top: 1px dashed rgba(20,40,30,0.08);
+}
+.loading-panel .log-detail-toggle {
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    color: var(--neutral-400);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    cursor: pointer;
+    user-select: none;
+    list-style: none;
+    padding: 2px 0;
+}
+.loading-panel .log-detail-toggle::-webkit-details-marker { display: none; }
+.loading-panel .log-detail-toggle::before {
+    content: "+ ";
+    color: var(--neutral-400);
+}
+.loading-panel .log-detail[open] .log-detail-toggle::before { content: "- "; }
+.loading-panel .log-stream {
+    max-height: 220px;
+    overflow-y: auto;
+    background: rgba(255,255,255,0.6);
+    border: 1px solid var(--neutral-100);
+    border-radius: 6px;
+    padding: 10px 12px;
+    margin-top: 8px;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    line-height: 1.55;
+    color: #334440;
+}
+.log-stream .log-line {
+    display: flex;
+    gap: 8px;
+    margin: 1px 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+.log-stream .log-prefix {
+    flex: 0 0 60px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+}
+.log-stream .log-prefix.mlb { color: #a76700; }
+.log-stream .log-prefix.mens { color: #3b6bb5; }
+.log-stream .log-prefix.womens { color: var(--purple-700); }
+.log-stream .log-prefix.system { color: var(--neutral-400); }
+.log-stream .log-line.done { color: var(--green-700); }
+.log-stream .log-line.failed { color: #b3463a; }
+.log-stream .log-text { flex: 1; }
 
 /* Refresh button (main area) */
 .main .stButton > button {
@@ -1074,16 +1251,48 @@ def _build_live_positions(positions, live_games) -> list[dict]:
 # ==========================================
 league_data = {}
 
+# Per-thread stdout splitter: each worker thread sets _THREAD_BUFFERS.buf to
+# a StringIO before running its prediction pipeline; print() calls in that
+# thread go to the buffer (and to the original stdout so terminal logs still
+# work). Main-thread writes pass through unchanged.
+_THREAD_BUFFERS = threading.local()
+
+
+class _ThreadDispatchStdout:
+    def __init__(self, fallback):
+        self._fallback = fallback
+
+    def write(self, s):
+        buf = getattr(_THREAD_BUFFERS, "buf", None)
+        if buf is not None:
+            buf.write(s)
+        return self._fallback.write(s)
+
+    def flush(self):
+        self._fallback.flush()
+
+    def isatty(self):
+        return False
+
 
 def _run_predictions(lg, spread_overrides=None):
-    """Run prediction pipeline for a single league. Thread-safe."""
-    if lg == "mlb":
-        mlb_predict.generate_predictions(lg)
-    else:
-        predict.main(
-            spread_overrides=spread_overrides or {},
-            league=lg,
-        )
+    """Run prediction pipeline for a single league. Thread-safe.
+
+    Captures the pipeline's stdout into a per-thread buffer so the dashboard
+    can stream the script's actual progress log instead of a blank spinner.
+    """
+    _THREAD_BUFFERS.buf = io.StringIO()
+    try:
+        if lg == "mlb":
+            mlb_predict.generate_predictions(lg)
+        else:
+            predict.main(
+                spread_overrides=spread_overrides or {},
+                league=lg,
+            )
+        return _THREAD_BUFFERS.buf.getvalue()
+    finally:
+        _THREAD_BUFFERS.buf = None
 
 
 # Determine which leagues need a prediction run
@@ -1111,25 +1320,110 @@ for lg in LEAGUES:
 
 # Run predictions in parallel (MLB is independent; mens/womens serialize via _RUNTIME_LOCK)
 if _leagues_to_run:
-    labels = [get_league_settings(lg)["label"] for lg in _leagues_to_run]
-    with st.spinner(f"Loading {', '.join(labels)}..."):
+    panel = st.empty()
+    statuses: dict[str, str] = {lg: "queued" for lg in _leagues_to_run}
+    activities: dict[str, str] = {lg: "queued" for lg in _leagues_to_run}
+    log_lines: list[str] = []
+
+    def _add_log(prefix_class: str, prefix: str, text: str, line_class: str = ""):
+        cls = f"log-line {line_class}".strip()
+        log_lines.append(
+            f'<div class="{cls}">'
+            f'<span class="log-prefix {prefix_class}">[{prefix}]</span>'
+            f'<span class="log-text">{html_mod.escape(text)}</span>'
+            f'</div>'
+        )
+
+    def _render_panel(running: bool = True):
+        n_done = sum(1 for s in statuses.values() if s in ("done", "failed"))
+        n_total = len(_leagues_to_run)
+        title = "Refreshing predictions" if running else "Predictions ready"
+        panel_cls = "loading-panel" + ("" if running else " complete")
+
+        rows = []
+        for lg in _leagues_to_run:
+            s = statuses[lg]
+            icon_glyph = {"done": "OK", "failed": "X"}.get(s, "")
+            activity = activities.get(lg) or s
+            rows.append(
+                f'<div class="lg-row">'
+                f'<span class="lg-icon {s}">{icon_glyph}</span>'
+                f'<span class="lg-tag {lg}">{lg}</span>'
+                f'<span class="lg-status {s}">{s}</span>'
+                f'<span class="lg-activity">{html_mod.escape(activity)}</span>'
+                f'</div>'
+            )
+        rows_html = "".join(rows)
+
+        details_html = ""
+        if log_lines:
+            stream = "".join(log_lines)
+            details_html = (
+                '<details class="log-detail">'
+                f'<summary class="log-detail-toggle">Full log ({len(log_lines)} lines)</summary>'
+                f'<div class="log-stream">{stream}</div>'
+                '</details>'
+            )
+
+        panel.markdown(
+            f'<div class="{panel_cls}">'
+            f'<div class="panel-header">'
+            f'<span class="panel-title">{html_mod.escape(title)}</span>'
+            f'<span class="panel-meta">{n_done} of {n_total} done</span>'
+            f'</div>'
+            f'<div class="progress-rail"><div class="progress-fill"></div></div>'
+            f'<div class="lg-rows">{rows_html}</div>'
+            f'{details_html}'
+            f'</div>',
+            unsafe_allow_html=True,
+        )
+
+    _add_log("system", "system", f"Spawning workers: {', '.join(_leagues_to_run)}")
+    _add_log("system", "system", "Sources: ESPN schedules, Kalshi, Polymarket")
+    _render_panel()
+
+    saved_stdout = sys.stdout
+    sys.stdout = _ThreadDispatchStdout(saved_stdout)
+    try:
         _errors = {}
         with ThreadPoolExecutor(max_workers=len(_leagues_to_run)) as executor:
             futures = {
                 executor.submit(_run_predictions, lg, _spread_overrides[lg]): lg
                 for lg in _leagues_to_run
             }
+            for lg in _leagues_to_run:
+                statuses[lg] = "running"
+                activities[lg] = "running pipeline"
+            _render_panel()
+
             for future in as_completed(futures):
                 lg = futures[future]
                 pred_file = _league_artifacts[lg]["paths"]["predictions_file"]
                 try:
-                    future.result()
+                    captured = future.result() or ""
                     if os.path.exists(pred_file):
                         st.session_state[f"predictions_loaded_{lg}"] = True
+                    last = ""
+                    for raw in captured.splitlines():
+                        line = raw.strip()
+                        if line:
+                            _add_log(lg, lg, line)
+                            last = line
+                    statuses[lg] = "done"
+                    activities[lg] = last or "done"
+                    _add_log(lg, lg, "done", line_class="done")
                 except Exception as e:
                     _errors[lg] = e
+                    statuses[lg] = "failed"
+                    activities[lg] = f"failed: {e}"
+                    _add_log(lg, lg, f"FAILED: {e}", line_class="failed")
+                _render_panel()
         for lg, e in _errors.items():
             st.error(f"Failed to load {get_league_settings(lg)['label']} predictions: {e}")
+    finally:
+        sys.stdout = saved_stdout
+
+    _render_panel(running=False)
 
 # Build league_data from prediction CSVs
 for lg in LEAGUES:

--- a/dashboard_helpers.py
+++ b/dashboard_helpers.py
@@ -3,6 +3,7 @@
 import re
 import sys
 import threading
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 
 import pandas as pd
@@ -90,6 +91,45 @@ def install_stdout_dispatcher() -> ThreadDispatchStdout:
     dispatcher = ThreadDispatchStdout()
     sys.stdout = dispatcher
     return dispatcher
+
+
+class _SilentSink:
+    """No-op write target used by silenced_stdout(). Implements the minimal
+    file-like protocol the dispatcher relies on."""
+
+    def write(self, s: str) -> int:
+        return len(s)
+
+    def flush(self) -> None:
+        pass
+
+    def isatty(self) -> bool:
+        return False
+
+
+@contextmanager
+def silenced_stdout():
+    """Suppress stdout on the *current thread only* via the installed
+    dispatcher's thread-local hook.
+
+    Use this instead of contextlib.redirect_stdout in the Streamlit app
+    path: redirect_stdout replaces process-global sys.stdout, which would
+    knock out ThreadDispatchStdout for every thread for the duration of
+    the context. A concurrent session refreshing predictions in another
+    tab would then lose its live worker capture and write into the
+    redirect buffer instead. This helper only changes the calling
+    thread's routing, so worker threads in other sessions are unaffected.
+    """
+    sentinel = object()
+    prior = getattr(THREAD_BUFFERS, "stream", sentinel)
+    THREAD_BUFFERS.stream = _SilentSink()
+    try:
+        yield
+    finally:
+        if prior is sentinel:
+            THREAD_BUFFERS.stream = None
+        else:
+            THREAD_BUFFERS.stream = prior
 
 
 def pilot_stake_units(model_units, cap: float = 0.5) -> float:

--- a/dashboard_helpers.py
+++ b/dashboard_helpers.py
@@ -1,9 +1,95 @@
 """Helpers for the Streamlit dashboard that can be imported without Streamlit."""
 
 import re
+import sys
+import threading
 from datetime import datetime, timedelta, timezone
 
 import pandas as pd
+
+
+# Per-thread stdout splitter used by the dashboard's loading panel. Each
+# worker sets THREAD_BUFFERS.stream to its own CapturedStream so print()s
+# inside the prediction pipeline are tee'd into a per-league log. Both
+# classes always defer to sys.__stdout__ -- never to whatever sys.stdout
+# currently points at -- so overlapping sessions that each install a
+# dispatcher cannot form a recursive fallback chain.
+THREAD_BUFFERS = threading.local()
+
+
+class CapturedStream:
+    """Thread-safe line-buffered stream for one worker's stdout.
+
+    write() is called from a single worker thread; consume_new() is called
+    from the main thread between waits. Lines are only finalized when a
+    newline is seen, so the activity preview never shows a half-flushed
+    line.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._lines: list[str] = []
+        self._partial = ""
+
+    def write(self, s: str) -> int:
+        if not s:
+            return 0
+        sys.__stdout__.write(s)
+        with self._lock:
+            self._partial += s
+            if "\n" in self._partial:
+                parts = self._partial.split("\n")
+                self._partial = parts[-1]
+                for line in parts[:-1]:
+                    stripped = line.strip()
+                    if stripped:
+                        self._lines.append(stripped)
+        return len(s)
+
+    def flush(self) -> None:
+        sys.__stdout__.flush()
+
+    def isatty(self) -> bool:
+        return False
+
+    def consume_new(self, offset: int) -> tuple[list[str], int]:
+        """Return new lines since `offset` and the new offset to remember."""
+        with self._lock:
+            return list(self._lines[offset:]), len(self._lines)
+
+
+class ThreadDispatchStdout:
+    """Routes a worker thread's writes to its CapturedStream; main-thread
+    writes (and writes from threads with no captured stream) pass through
+    to sys.__stdout__ -- never to a previously installed dispatcher, so
+    nested sessions can't form a recursive chain."""
+
+    def write(self, s: str) -> int:
+        stream = getattr(THREAD_BUFFERS, "stream", None)
+        if stream is not None:
+            return stream.write(s)
+        return sys.__stdout__.write(s)
+
+    def flush(self) -> None:
+        sys.__stdout__.flush()
+
+    def isatty(self) -> bool:
+        return False
+
+
+def install_stdout_dispatcher() -> ThreadDispatchStdout:
+    """Install the dispatcher on sys.stdout once per process.
+
+    Streamlit reruns the script top-to-bottom on every interaction, so the
+    install has to be idempotent; we use isinstance to detect "already
+    installed" and skip the swap. Returns the installed dispatcher.
+    """
+    current = sys.stdout
+    if isinstance(current, ThreadDispatchStdout):
+        return current
+    dispatcher = ThreadDispatchStdout()
+    sys.stdout = dispatcher
+    return dispatcher
 
 
 def pilot_stake_units(model_units, cap: float = 0.5) -> float:

--- a/tests/test_stdout_capture.py
+++ b/tests/test_stdout_capture.py
@@ -28,6 +28,7 @@ from dashboard_helpers import (
     THREAD_BUFFERS,
     ThreadDispatchStdout,
     install_stdout_dispatcher,
+    silenced_stdout,
 )
 
 
@@ -170,6 +171,72 @@ def test_worker_threads_isolate_captures(fresh_stdout):
     b_lines, _ = streams["b"].consume_new(0)
     assert a_lines == [f"a-{i}" for i in range(20)]
     assert b_lines == [f"b-{i}" for i in range(20)]
+
+
+def test_silenced_stdout_only_affects_calling_thread(fresh_stdout):
+    """The main thread can suppress its own stdout (e.g. while running the
+    backtest) without breaking a concurrent worker's capture in another
+    Streamlit session.
+
+    Pins the invariant that ruled out contextlib.redirect_stdout: a global
+    stdout swap would have routed *every* thread's writes into the
+    silencing sink, so the worker's CapturedStream would have collected
+    nothing.
+    """
+    install_stdout_dispatcher()
+
+    worker_stream = CapturedStream()
+    worker_started = threading.Event()
+    main_inside_silenced = threading.Event()
+    worker_done = threading.Event()
+    worker_lines: list[str] = []
+
+    def _worker() -> None:
+        THREAD_BUFFERS.stream = worker_stream
+        try:
+            worker_started.set()
+            # Hold here until the main thread is inside silenced_stdout(),
+            # then emit -- this is exactly the scenario the finding flagged.
+            assert main_inside_silenced.wait(timeout=2)
+            for i in range(10):
+                print(f"worker-{i}")
+        finally:
+            THREAD_BUFFERS.stream = None
+            worker_done.set()
+
+    t = threading.Thread(target=_worker)
+    t.start()
+    assert worker_started.wait(timeout=2)
+
+    with silenced_stdout():
+        main_inside_silenced.set()
+        # Anything we print on the main thread now must be swallowed.
+        print("main-should-be-silenced")
+        assert worker_done.wait(timeout=5)
+
+    t.join(timeout=5)
+    assert not t.is_alive()
+
+    worker_lines, _ = worker_stream.consume_new(0)
+    assert worker_lines == [f"worker-{i}" for i in range(10)]
+
+
+def test_silenced_stdout_restores_previous_thread_local(fresh_stdout):
+    """Nested or re-entrant silencing must not clobber a prior thread-local
+    stream set by an outer caller (e.g. a worker that already opted in)."""
+    install_stdout_dispatcher()
+    outer = CapturedStream()
+    THREAD_BUFFERS.stream = outer
+    try:
+        with silenced_stdout():
+            print("swallowed")
+        # After the context, the outer capture must be back in place.
+        assert THREAD_BUFFERS.stream is outer
+        print("after-silenced")
+        new, _ = outer.consume_new(0)
+        assert new == ["after-silenced"]
+    finally:
+        THREAD_BUFFERS.stream = None
 
 
 def test_captured_stream_concurrent_writer_and_reader(fresh_stdout):

--- a/tests/test_stdout_capture.py
+++ b/tests/test_stdout_capture.py
@@ -1,0 +1,205 @@
+"""Regression tests for the dashboard's per-thread stdout capture.
+
+The loading panel installs a process-global ThreadDispatchStdout on
+sys.stdout. Two overlapping Streamlit sessions used to wrap each other's
+dispatchers, which - combined with a thread-local stream that's shared
+across dispatcher hops - produced infinite recursion on the first worker
+write. These tests pin the invariants that prevent that:
+
+  * Both helpers always fall back to sys.__stdout__, never to whatever
+    sys.stdout currently points at.
+  * install_stdout_dispatcher() is idempotent across reruns and does not
+    chain dispatchers.
+  * Concurrent workers each see their own CapturedStream and do not bleed
+    output into each other.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+import threading
+import time
+
+import pytest
+
+from dashboard_helpers import (
+    CapturedStream,
+    THREAD_BUFFERS,
+    ThreadDispatchStdout,
+    install_stdout_dispatcher,
+)
+
+
+@pytest.fixture
+def fresh_stdout():
+    """Save and restore sys.stdout around tests that mutate it."""
+    original = sys.stdout
+    try:
+        yield
+    finally:
+        sys.stdout = original
+        THREAD_BUFFERS.stream = None
+
+
+def test_captured_stream_lines_finalize_on_newline(fresh_stdout):
+    s = CapturedStream()
+    s.write("hello")
+    new, offset = s.consume_new(0)
+    assert new == []  # nothing finalized yet -- no \n
+    assert offset == 0
+
+    s.write(" world\n")
+    new, offset = s.consume_new(0)
+    assert new == ["hello world"]
+    assert offset == 1
+
+
+def test_captured_stream_handles_multi_line_chunks(fresh_stdout):
+    s = CapturedStream()
+    s.write("a\nb\nc")
+    new, offset = s.consume_new(0)
+    assert new == ["a", "b"]  # "c" still partial
+    assert offset == 2
+
+    s.write("d\n")  # finalizes "cd"
+    more, offset2 = s.consume_new(offset)
+    assert more == ["cd"]
+    assert offset2 == 3
+
+
+def test_captured_stream_strips_whitespace_only_lines(fresh_stdout):
+    s = CapturedStream()
+    s.write("real\n   \n  \nother\n")
+    new, _ = s.consume_new(0)
+    assert new == ["real", "other"]
+
+
+def test_install_dispatcher_is_idempotent(fresh_stdout):
+    first = install_stdout_dispatcher()
+    second = install_stdout_dispatcher()
+    third = install_stdout_dispatcher()
+    assert first is second is third
+    assert sys.stdout is first
+    assert isinstance(sys.stdout, ThreadDispatchStdout)
+
+
+def test_dispatcher_falls_back_to_original_stdout_not_previous_dispatcher(
+    fresh_stdout,
+):
+    """Critical recursion-safety invariant.
+
+    If a dispatcher's fallback were `sys.stdout` at install time -- which
+    might already be a dispatcher from an earlier overlapping session --
+    a worker write would route DispatchB -> stream -> DispatchA -> stream
+    -> DispatchA... until the stack blew up. We pin that the helpers
+    always defer to sys.__stdout__ instead, so the chain has length 1.
+    """
+    # Pretend an earlier session installed dispatcher A.
+    install_stdout_dispatcher()
+    a = sys.stdout
+
+    # Simulate the previously-buggy second install: even if we forcibly
+    # construct a fresh ThreadDispatchStdout instance (e.g. via test or
+    # cold-start race), its writes must still target sys.__stdout__, not
+    # whatever sys.stdout is at construction time.
+    b = ThreadDispatchStdout()
+    sys.stdout = b
+
+    captured = CapturedStream()
+    THREAD_BUFFERS.stream = captured
+    try:
+        # A single print() must not recurse. If b.write routed through
+        # a.write (and both checked the same thread-local), we'd loop until
+        # RecursionError. Bound the recursion check by setting a low limit.
+        prev_limit = sys.getrecursionlimit()
+        sys.setrecursionlimit(50)
+        try:
+            print("ping")  # routes through b.write -> captured.write -> sys.__stdout__
+        finally:
+            sys.setrecursionlimit(prev_limit)
+    finally:
+        THREAD_BUFFERS.stream = None
+        sys.stdout = a
+
+    new, _ = captured.consume_new(0)
+    assert new == ["ping"]
+
+
+def test_main_thread_writes_pass_through_when_no_capture(fresh_stdout):
+    """Without a thread-local stream set, dispatcher writes must go to
+    sys.__stdout__ and not affect any CapturedStream."""
+    install_stdout_dispatcher()
+    captured = CapturedStream()
+    # NOTE: do *not* set THREAD_BUFFERS.stream here -- we're simulating the
+    # main thread, which never opts in.
+    print("not-captured-on-main")
+    new, _ = captured.consume_new(0)
+    assert new == []  # captured saw nothing because it was never registered
+
+
+def test_worker_threads_isolate_captures(fresh_stdout):
+    """Two threads each register their own CapturedStream; their writes
+    must not bleed into each other or recurse."""
+    install_stdout_dispatcher()
+
+    streams = {"a": CapturedStream(), "b": CapturedStream()}
+    barrier = threading.Barrier(3)
+
+    def _worker(tag: str) -> None:
+        THREAD_BUFFERS.stream = streams[tag]
+        try:
+            barrier.wait()  # release all three together
+            for i in range(20):
+                print(f"{tag}-{i}")
+        finally:
+            THREAD_BUFFERS.stream = None
+
+    threads = [
+        threading.Thread(target=_worker, args=("a",)),
+        threading.Thread(target=_worker, args=("b",)),
+    ]
+    for t in threads:
+        t.start()
+    barrier.wait()
+    for t in threads:
+        t.join(timeout=5)
+        assert not t.is_alive()
+
+    a_lines, _ = streams["a"].consume_new(0)
+    b_lines, _ = streams["b"].consume_new(0)
+    assert a_lines == [f"a-{i}" for i in range(20)]
+    assert b_lines == [f"b-{i}" for i in range(20)]
+
+
+def test_captured_stream_concurrent_writer_and_reader(fresh_stdout):
+    """consume_new() called concurrently with write() must not crash or
+    deadlock, and every line emitted must eventually be readable in order."""
+    s = CapturedStream()
+    n_lines = 500
+    done = threading.Event()
+
+    def _writer() -> None:
+        for i in range(n_lines):
+            s.write(f"line-{i}\n")
+        done.set()
+
+    seen: list[str] = []
+    offset = 0
+
+    def _reader() -> None:
+        nonlocal offset
+        while not done.is_set() or offset < n_lines:
+            new, offset_new = s.consume_new(offset)
+            seen.extend(new)
+            offset = offset_new
+            time.sleep(0.001)
+
+    t1 = threading.Thread(target=_writer)
+    t2 = threading.Thread(target=_reader)
+    t1.start()
+    t2.start()
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+    assert not t1.is_alive() and not t2.is_alive()
+    assert seen == [f"line-{i}" for i in range(n_lines)]


### PR DESCRIPTION
## Summary
The MLB Today panel was previously a stripped-down candidate list while the actually-used surface (bulleted candidate callout + SP-aware table) was buried at the bottom Full Slates -> MLB tab. The user reported scrolling down to that section every time and asked for a visual cleanup.

This PR makes MLB Today self-sufficient and trims the redundant duplication:

- **MLB Today panel** now carries:
  - The bulleted candidate summary (matching the bottom green callout)
  - A candidate-only table with `Home_SP`, `Away_SP`, `Prod Pick`, `Odds`, `Prod Conf`, `Shadow Edge`, `Rating`, `Pilot Stake`
  - One concise "verify before placing" caption at the end
- **Verbose noise removed**:
  - Dropped the gate-criteria parenthetical (`Std_Rating GOOD/STRONG, shadow ok, ...`)
  - Dropped the standalone "Still verify manually before betting" footer block
- **Bottom Full Slates -> MLB** keeps its diagnostic dataframe (with `Bet?=yes` pinned candidates) but no longer renders its own duplicate green candidate callout.

## Test plan
- [x] `pytest tests/test_dashboard_helpers.py tests/test_token_bet_candidate.py -q` -- 23 passed (helpers unchanged)
- [x] Local dev server (`uv run streamlit run app.py`) verified visually:
  - Top of page: freshness banner -> MLB Today section with rich callout + SP-aware candidate table
  - Bottom Full Slates -> MLB: diagnostic table, candidates pinned to top with `Bet?=yes`, no duplicate callout
- [ ] After merge, eyeball on the production dashboard