### PR TITLE
Harden FanDuel settled-card OCR against partial screenshots

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -1358,14 +1358,8 @@ def _parse_single_fd_settled_card(card_text: str) -> dict | None:
     elif "lost on fanduel" in lower or re.search(r"^\s*lost\s*$", lower, re.MULTILINE):
         result = "loss"
     elif re.search(r"^\s*returned\s*$", lower, re.MULTILINE):
-        # RETURNED present -- distinguish loss ($0.00 payout) from void (wager
-        # refunded). FanDuel renders $0.00 alongside RETURNED for losses, but
-        # the [0.25, 500] range filter excludes it, so a real loss often shows
-        # only the wager amount in range. We accept that as a loss ONLY when an
-        # explicit "$0.00" / "$0.0" substring is also present. Without that
-        # confirming marker, partial OCR could just as easily have dropped a
-        # winning payout amount, so we mark the card ambiguous and skip the
-        # write -- the user is prompted to re-screenshot rather than risk a
+        # Without an explicit $0.00 marker, a missing second amount could
+        # equally be a dropped winning payout -- prefer ambiguous over a
         # silently-mislabeled loss.
         ret_amts = re.findall(r"\$(\d+\.?\d{0,2})", card_text)
         ret_in_range = [float(m) for m in ret_amts if 0.25 <= float(m) <= 500]
@@ -2465,6 +2459,93 @@ async def cmd_delete(update: Update, context: ContextTypes.DEFAULT_TYPE):
 # --- Message handlers ---
 
 
+# Skip reasons that should surface as "Missed: ..." cards in the user feedback.
+# Anything else (dedup, unsettled) is shown via aggregate footer lines instead.
+_NEEDS_REVIEW_REASONS = ("incomplete", "ambiguous_returned")
+_SKIP_REASON_LABELS = {
+    "incomplete": "incomplete",
+    "ambiguous_returned": "ambiguous (RETURNED w/o $0.00)",
+}
+
+
+def _format_missed_card_label(skip: dict) -> str:
+    """Render the identifying label for one missed/ambiguous skip dict."""
+    parts: list[str] = []
+    for key in ("line", "team", "game"):
+        if skip.get(key):
+            parts.append(str(skip[key]))
+            break
+    if skip.get("bet_id"):
+        parts.append(f"BET ID {skip['bet_id']}")
+    wager = skip.get("wager") or 0
+    if wager > 0:
+        parts.append(f"${wager:.2f}")
+    result = skip.get("result")
+    if result and result not in ("pending", "ambiguous_returned"):
+        parts.append(str(result).upper())
+    return ", ".join(parts) if parts else "card with no identifying fields"
+
+
+def _build_skip_feedback_messages(
+    skipped: list[dict],
+    has_actual_settled: bool,
+) -> list[str]:
+    """Build user-visible feedback for skipped settled-card entries.
+
+    One "Missed [reason]: label" line per needs-review skip so the user never
+    has to guess which card was dropped. Unknown _skip_reason values are
+    logged and treated as needs-review so a new failure mode can't slip
+    through silently.
+    """
+    msgs: list[str] = []
+    if not skipped:
+        return msgs
+
+    by_reason: dict[str, list[dict]] = {}
+    for s in skipped:
+        by_reason.setdefault(s.get("_skip_reason", "?"), []).append(s)
+    skipped_dedup = by_reason.pop("dedup", [])
+    skipped_unsettled = by_reason.pop("unsettled", [])
+    needs_review: list[dict] = []
+    for reason in _NEEDS_REVIEW_REASONS:
+        needs_review.extend(by_reason.pop(reason, []))
+    if by_reason:
+        logger.error(
+            "Unknown OCR _skip_reason value(s): %s", sorted(by_reason.keys())
+        )
+        for items in by_reason.values():
+            needs_review.extend(items)
+
+    if (
+        not has_actual_settled
+        and not needs_review
+        and not skipped_unsettled
+        and skipped_dedup
+    ):
+        msgs.append(
+            f"{len(skipped_dedup)} bet(s) already processed from a previous screenshot."
+        )
+        return msgs
+
+    for s in needs_review:
+        reason_key = s.get("_skip_reason", "?")
+        reason_label = _SKIP_REASON_LABELS.get(reason_key, reason_key)
+        msgs.append(
+            f"Missed [{reason_label}]: {_format_missed_card_label(s)}"
+        )
+    if needs_review:
+        msgs.append("Scroll to show full cards and resend for missed bets.")
+
+    if skipped_unsettled:
+        n = len(skipped_unsettled)
+        lines = [s.get("line", "?") for s in skipped_unsettled]
+        msgs.append(
+            f"Skipped {n} open/unsettled card(s): {', '.join(lines)}. "
+            "Send again after they settle."
+        )
+    return msgs
+
+
 @authorized_only
 async def handle_photo(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handle bet slip screenshot via macOS OCR."""
@@ -2532,11 +2613,6 @@ async def handle_photo(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if settled_all:
         actual_settled = [b for b in settled_all if not b.get("_skipped")]
         skipped = [b for b in settled_all if b.get("_skipped")]
-        skipped_incomplete = [s for s in skipped if s.get("_skip_reason") == "incomplete"]
-        skipped_dedup = [s for s in skipped if s.get("_skip_reason") == "dedup"]
-        skipped_unsettled = [s for s in skipped if s.get("_skip_reason") == "unsettled"]
-        skipped_ambiguous = [s for s in skipped if s.get("_skip_reason") == "ambiguous_returned"]
-        skipped_needs_review = skipped_incomplete + skipped_ambiguous
 
         msgs = []
         for bet in actual_settled:
@@ -2573,53 +2649,11 @@ async def handle_photo(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 logger.exception("Unexpected error logging settled bet %s: %s", bet.get("bet_id", "?"), e)
                 msgs.append(f"Unexpected error processing {bet.get('line', '?')}. Check bot logs.")
 
-        # Per-card skip feedback
-        if (
-            not actual_settled
-            and not skipped_needs_review
-            and not skipped_unsettled
-            and skipped_dedup
-        ):
-            # All cards were deduped, no new bets
-            msgs.append(f"{len(skipped_dedup)} bet(s) already processed from a previous screenshot.")
-        elif not actual_settled and not skipped:
-            # Nothing parsed at all
-            msgs.append(
-                "No bets could be parsed. Cards may be partially visible"
-                " -- try scrolling to show complete cards and resend."
+        msgs.extend(
+            _build_skip_feedback_messages(
+                skipped, has_actual_settled=bool(actual_settled)
             )
-        else:
-            # Show missed incomplete + ambiguous cards. Always emit one line per
-            # missed card so the user knows the count even when OCR captured
-            # almost nothing -- a silent skip is the failure mode we're trying
-            # to eliminate.
-            for s in skipped_needs_review:
-                parts = []
-                if s.get("line"):
-                    parts.append(s["line"])
-                elif s.get("team"):
-                    parts.append(s["team"])
-                elif s.get("game"):
-                    parts.append(s["game"])
-                if s.get("bet_id"):
-                    parts.append(f"BET ID {s['bet_id']}")
-                if s.get("wager") and s["wager"] > 0:
-                    parts.append(f"${s['wager']:.2f}")
-                if s.get("result") and s["result"] not in ("pending", "ambiguous_returned"):
-                    parts.append(s["result"].upper())
-                label = ", ".join(parts) if parts else "card with no identifying fields"
-                reason = "ambiguous (RETURNED w/o $0.00)" if s.get("_skip_reason") == "ambiguous_returned" else "incomplete"
-                msgs.append(f"Missed [{reason}]: {label}")
-            if skipped_needs_review:
-                msgs.append("Scroll to show full cards and resend for missed bets.")
-            # Show unsettled/open cards that were skipped
-            if skipped_unsettled:
-                n = len(skipped_unsettled)
-                lines = [s.get("line", "?") for s in skipped_unsettled]
-                msgs.append(
-                    f"Skipped {n} open/unsettled card(s): {', '.join(lines)}. "
-                    "Send again after they settle."
-                )
+        )
 
         if msgs:
             await update.message.reply_text("\n".join(msgs))

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -1358,18 +1358,28 @@ def _parse_single_fd_settled_card(card_text: str) -> dict | None:
     elif "lost on fanduel" in lower or re.search(r"^\s*lost\s*$", lower, re.MULTILINE):
         result = "loss"
     elif re.search(r"^\s*returned\s*$", lower, re.MULTILINE):
-        # RETURNED present -- distinguish loss ($0.00 payout) from void (wager refunded).
-        # Extract dollar amounts in betting range; if two found and approximately
-        # equal, wager was refunded (void). Otherwise loss.
+        # RETURNED present -- distinguish loss ($0.00 payout) from void (wager
+        # refunded). FanDuel renders $0.00 alongside RETURNED for losses, but
+        # the [0.25, 500] range filter excludes it, so a real loss often shows
+        # only the wager amount in range. We accept that as a loss ONLY when an
+        # explicit "$0.00" / "$0.0" substring is also present. Without that
+        # confirming marker, partial OCR could just as easily have dropped a
+        # winning payout amount, so we mark the card ambiguous and skip the
+        # write -- the user is prompted to re-screenshot rather than risk a
+        # silently-mislabeled loss.
         ret_amts = re.findall(r"\$(\d+\.?\d{0,2})", card_text)
         ret_in_range = [float(m) for m in ret_amts if 0.25 <= float(m) <= 500]
+        zero_payout_marker = bool(re.search(r"\$0+\.0{1,2}\b", card_text))
         if len(ret_in_range) >= 2 and abs(ret_in_range[1] - ret_in_range[0]) < 0.01:
             result = "void"
-        else:
+        elif len(ret_in_range) >= 2 or zero_payout_marker:
             result = "loss"
+        else:
+            result = "ambiguous_returned"
         logger.info(
-            "FD settled card: RETURNED -> %s (bet_id=%s, amounts_in_range=%s)",
-            result, bet_id, ret_in_range,
+            "FD settled card: RETURNED -> %s "
+            "(bet_id=%s, amounts_in_range=%s, zero_marker=%s)",
+            result, bet_id, ret_in_range, zero_payout_marker,
         )
     else:
         # No keyword markers found.  If there's no BET ID either, this is
@@ -1621,6 +1631,19 @@ def _parse_single_fd_settled_card(card_text: str) -> dict | None:
             game_date, bet_id,
         )
 
+    if result == "ambiguous_returned":
+        logger.warning(
+            "FD settled card: RETURNED with no $0.00 marker and < 2 in-range "
+            "amounts, skipping as ambiguous (bet_id=%s line=%r wager=%s)",
+            bet_id, line, wager,
+        )
+        return {
+            "_skipped": True, "_skip_reason": "ambiguous_returned", "_settled": True,
+            "platform": "FanDuel",
+            "bet_id": bet_id, "wager": wager, "result": result,
+            "game": game, "line": line, "team": team,
+        }
+
     if not line or wager <= 0:
         logger.warning(
             "FD settled card parse incomplete: line=%r wager=%s bet_id=%s",
@@ -1629,7 +1652,8 @@ def _parse_single_fd_settled_card(card_text: str) -> dict | None:
         return {
             "_skipped": True, "_skip_reason": "incomplete", "_settled": True,
             "platform": "FanDuel",
-            "bet_id": bet_id, "wager": wager, "result": result, "game": game,
+            "bet_id": bet_id, "wager": wager, "result": result,
+            "game": game, "line": line, "team": team,
         }
 
     if result == "pending":
@@ -2511,6 +2535,8 @@ async def handle_photo(update: Update, context: ContextTypes.DEFAULT_TYPE):
         skipped_incomplete = [s for s in skipped if s.get("_skip_reason") == "incomplete"]
         skipped_dedup = [s for s in skipped if s.get("_skip_reason") == "dedup"]
         skipped_unsettled = [s for s in skipped if s.get("_skip_reason") == "unsettled"]
+        skipped_ambiguous = [s for s in skipped if s.get("_skip_reason") == "ambiguous_returned"]
+        skipped_needs_review = skipped_incomplete + skipped_ambiguous
 
         msgs = []
         for bet in actual_settled:
@@ -2548,7 +2574,12 @@ async def handle_photo(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 msgs.append(f"Unexpected error processing {bet.get('line', '?')}. Check bot logs.")
 
         # Per-card skip feedback
-        if not actual_settled and not skipped_incomplete and not skipped_unsettled and skipped_dedup:
+        if (
+            not actual_settled
+            and not skipped_needs_review
+            and not skipped_unsettled
+            and skipped_dedup
+        ):
             # All cards were deduped, no new bets
             msgs.append(f"{len(skipped_dedup)} bet(s) already processed from a previous screenshot.")
         elif not actual_settled and not skipped:
@@ -2558,18 +2589,28 @@ async def handle_photo(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 " -- try scrolling to show complete cards and resend."
             )
         else:
-            # Show missed incomplete cards
-            for s in skipped_incomplete:
+            # Show missed incomplete + ambiguous cards. Always emit one line per
+            # missed card so the user knows the count even when OCR captured
+            # almost nothing -- a silent skip is the failure mode we're trying
+            # to eliminate.
+            for s in skipped_needs_review:
                 parts = []
+                if s.get("line"):
+                    parts.append(s["line"])
+                elif s.get("team"):
+                    parts.append(s["team"])
+                elif s.get("game"):
+                    parts.append(s["game"])
                 if s.get("bet_id"):
                     parts.append(f"BET ID {s['bet_id']}")
                 if s.get("wager") and s["wager"] > 0:
                     parts.append(f"${s['wager']:.2f}")
-                if s.get("result") and s["result"] != "pending":
+                if s.get("result") and s["result"] not in ("pending", "ambiguous_returned"):
                     parts.append(s["result"].upper())
-                if parts:
-                    msgs.append(f"Missed: {', '.join(parts)}")
-            if skipped_incomplete:
+                label = ", ".join(parts) if parts else "card with no identifying fields"
+                reason = "ambiguous (RETURNED w/o $0.00)" if s.get("_skip_reason") == "ambiguous_returned" else "incomplete"
+                msgs.append(f"Missed [{reason}]: {label}")
+            if skipped_needs_review:
                 msgs.append("Scroll to show full cards and resend for missed bets.")
             # Show unsettled/open cards that were skipped
             if skipped_unsettled:

--- a/tests/test_telegram_ocr_regression.py
+++ b/tests/test_telegram_ocr_regression.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 import importlib
 import importlib.util
+import logging
 import sys
 import types
 
@@ -951,12 +952,7 @@ def test_placed_date_validation_rejects_out_of_range() -> None:
 
 
 def test_returned_with_zero_payout_and_one_in_range_amount_is_loss() -> None:
-    """RETURNED + $0.00 substring + only the wager in [0.25, 500]: confident loss.
-
-    Regression for FanDuel 'Finished' cards where the wager renders in-range
-    (e.g. $0.50) but $0.00 fails the range filter -- we still want a loss,
-    not an ambiguous skip.
-    """
+    """$0.00 payout fails the in-range filter; explicit $0.00 substring confirms loss."""
     card_text = "\n".join([
         "FANDUEL",
         "SPORTSBOOK",
@@ -979,12 +975,7 @@ def test_returned_with_zero_payout_and_one_in_range_amount_is_loss() -> None:
 
 
 def test_returned_with_one_amount_and_no_zero_marker_is_ambiguous() -> None:
-    """RETURNED + only one in-range amount AND no $0.00 anywhere: skip ambiguous.
-
-    Without an explicit $0.00 marker we can't tell if the missing dollar amount
-    was a payout (loss/void) or a winning return that OCR dropped. Better to
-    surface to the user than silently log as loss.
-    """
+    """Missing payout amount could equally be a dropped winner -- skip, don't lock in loss."""
     card_text = "\n".join([
         "FANDUEL",
         "SPORTSBOOK",
@@ -1010,7 +1001,7 @@ def test_returned_with_one_amount_and_no_zero_marker_is_ambiguous() -> None:
 
 
 def test_ambiguous_returned_does_not_burn_bet_id() -> None:
-    """Ambiguous RETURNED skip lets a follow-up clean screenshot parse the bet."""
+    """A re-screenshot with full data must still parse after an ambiguous skip."""
     ambiguous_card = "\n".join([
         "FANDUEL",
         "SPORTSBOOK",
@@ -1047,25 +1038,169 @@ def test_ambiguous_returned_does_not_burn_bet_id() -> None:
 
 
 def test_incomplete_skip_includes_line_for_user_feedback() -> None:
-    """Incomplete skip dicts should expose the parsed team line (when known).
-
-    Today's failure: an empty-bet_id partial card with line='Minnesota Twins ML'
-    and wager=0 produced no Telegram feedback because the skip dict only had
-    bet_id/wager/result/game -- none populated. Including `line` lets the
-    user know which card was missed.
-    """
+    """Skip dict must expose the parsed team line so empty-bet_id cards aren't silent."""
     card_text = "\n".join([
         "FANDUEL",
         "SPORTSBOOK",
-        "Minnesota Twins ML",
+        "Minnesota Twins",
         "+100",
         "MONEYLINE",
         "Minnesota Twins ( Ryan) @ Cleveland Guardia...",
     ])
     bets = BOT._parse_fd_settled_cards(card_text)
     skipped = [b for b in bets if b.get("_skipped")]
-    # Card has no result keywords, no $ amounts -> unsettled/pending skip
     assert len(skipped) == 1
     s = skipped[0]
-    # team/line surface so the user can identify the missed bet
-    assert s.get("line") or s.get("team") or s.get("game")
+    assert s["line"] == "Minnesota Twins ML"
+    assert s["team"] == "Minnesota Twins"
+
+
+def test_returned_with_zero_in_range_amounts_and_no_marker_is_ambiguous() -> None:
+    """Zero usable amounts and no $0.00 marker -- can't even confirm a wager was placed."""
+    card_text = "\n".join([
+        "FANDUEL",
+        "SPORTSBOOK",
+        "Houston Astros ML",
+        "+116",
+        "MONEYLINE",
+        "RETURNED",
+        "BET ID: 0/0084650/9999260",
+        "PLACED: 5/10/2026 6:32PM ET",
+    ])
+    bets = BOT._parse_fd_settled_cards(card_text)
+    skipped = [b for b in bets if b.get("_skipped")]
+    assert skipped and skipped[0]["_skip_reason"] == "ambiguous_returned"
+
+
+def test_returned_with_bare_zero_no_dollar_sign_is_ambiguous() -> None:
+    """Bare '0.00' without a $ prefix is not enough -- the marker contract requires $0.00."""
+    card_text = "\n".join([
+        "FANDUEL",
+        "SPORTSBOOK",
+        "Houston Astros ML",
+        "+116",
+        "MONEYLINE",
+        "$0.50",
+        "0.00",
+        "TOTAL WAGER",
+        "RETURNED",
+        "BET ID: 0/0084650/9999261",
+        "PLACED: 5/10/2026 6:32PM ET",
+    ])
+    bets = BOT._parse_fd_settled_cards(card_text)
+    skipped = [b for b in bets if b.get("_skipped")]
+    actual = _actual_bets(bets)
+    assert actual == []
+    assert skipped and skipped[0]["_skip_reason"] == "ambiguous_returned"
+
+
+def test_returned_with_zero_dollar_zero_single_decimal_is_loss() -> None:
+    """$0.0 (one trailing digit) is also a valid zero-payout marker."""
+    card_text = "\n".join([
+        "FANDUEL",
+        "SPORTSBOOK",
+        "Houston Astros ML",
+        "+116",
+        "MONEYLINE",
+        "$0.50",
+        "$0.0",
+        "TOTAL WAGER",
+        "RETURNED",
+        "BET ID: 0/0084650/9999262",
+        "PLACED: 5/10/2026 6:32PM ET",
+    ])
+    bets = BOT._parse_fd_settled_cards(card_text)
+    actual = _actual_bets(bets)
+    assert len(actual) == 1
+    assert actual[0]["result"] == "loss"
+
+
+# ---------------------------------------------------------------------------
+# Skip-feedback helper tests (extracted from handle_photo for testability)
+# ---------------------------------------------------------------------------
+
+
+def test_format_missed_card_label_prefers_line_over_team() -> None:
+    label = BOT._format_missed_card_label(
+        {"line": "Drexel -1.5", "team": "Drexel", "game": "Drexel vs Towson"}
+    )
+    assert label.startswith("Drexel -1.5")
+    assert "Drexel vs Towson" not in label  # game not appended once line is present
+
+
+def test_format_missed_card_label_falls_back_to_team_then_game() -> None:
+    assert BOT._format_missed_card_label({"team": "Drexel"}) == "Drexel"
+    assert BOT._format_missed_card_label({"game": "Drexel vs Towson"}) == "Drexel vs Towson"
+
+
+def test_format_missed_card_label_handles_all_empty_fields() -> None:
+    assert BOT._format_missed_card_label({}) == "card with no identifying fields"
+    assert (
+        BOT._format_missed_card_label({"line": "", "team": "", "bet_id": "", "wager": 0})
+        == "card with no identifying fields"
+    )
+
+
+def test_format_missed_card_label_hides_internal_result_values() -> None:
+    """`pending` and `ambiguous_returned` are internal sentinels -- don't surface them."""
+    pending = BOT._format_missed_card_label({"line": "X ML", "result": "pending"})
+    ambiguous = BOT._format_missed_card_label({"line": "X ML", "result": "ambiguous_returned"})
+    assert "PENDING" not in pending
+    assert "AMBIGUOUS_RETURNED" not in ambiguous
+
+
+def test_build_skip_feedback_emits_one_line_per_needs_review_card() -> None:
+    skipped = [
+        {"_skip_reason": "incomplete", "line": "Drexel -1.5"},
+        {"_skip_reason": "ambiguous_returned", "line": "Houston Astros ML",
+         "bet_id": "BID-9", "wager": 0.5},
+    ]
+    msgs = BOT._build_skip_feedback_messages(skipped, has_actual_settled=False)
+    missed = [m for m in msgs if m.startswith("Missed [")]
+    assert len(missed) == 2
+    assert any("Drexel -1.5" in m and "[incomplete]" in m for m in missed)
+    assert any("Houston Astros ML" in m and "ambiguous" in m for m in missed)
+
+
+def test_build_skip_feedback_uses_no_identifying_fields_label_when_empty() -> None:
+    msgs = BOT._build_skip_feedback_messages(
+        [{"_skip_reason": "incomplete"}], has_actual_settled=False
+    )
+    assert any("card with no identifying fields" in m for m in msgs)
+
+
+def test_build_skip_feedback_collapses_all_dedup_only_into_summary() -> None:
+    msgs = BOT._build_skip_feedback_messages(
+        [
+            {"_skip_reason": "dedup", "bet_id": "A"},
+            {"_skip_reason": "dedup", "bet_id": "B"},
+        ],
+        has_actual_settled=False,
+    )
+    assert msgs == ["2 bet(s) already processed from a previous screenshot."]
+
+
+def test_build_skip_feedback_emits_unsettled_footer() -> None:
+    msgs = BOT._build_skip_feedback_messages(
+        [{"_skip_reason": "unsettled", "line": "Drexel -1.5"}],
+        has_actual_settled=False,
+    )
+    joined = "\n".join(msgs)
+    assert "Drexel -1.5" in joined
+    assert "open/unsettled" in joined
+
+
+def test_build_skip_feedback_surfaces_unknown_skip_reasons(caplog) -> None:
+    """An unrecognized _skip_reason must be logged AND shown to the user."""
+    caplog.set_level(logging.ERROR, logger="telegram_bot")
+    msgs = BOT._build_skip_feedback_messages(
+        [{"_skip_reason": "future_reason_we_have_not_added_yet", "line": "X ML"}],
+        has_actual_settled=False,
+    )
+    assert any("Unknown OCR _skip_reason" in r.getMessage() for r in caplog.records)
+    assert any("X ML" in m for m in msgs)  # surfaced, not silently dropped
+
+
+def test_build_skip_feedback_empty_input_returns_empty() -> None:
+    assert BOT._build_skip_feedback_messages([], has_actual_settled=True) == []
+    assert BOT._build_skip_feedback_messages([], has_actual_settled=False) == []

--- a/tests/test_telegram_ocr_regression.py
+++ b/tests/test_telegram_ocr_regression.py
@@ -943,3 +943,129 @@ def test_placed_date_validation_rejects_out_of_range() -> None:
     actual = _actual_bets(bets)
     assert len(actual) == 1
     assert actual[0]["date"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Hardened OCR confidence gating (RETURNED ambiguity + skip feedback)
+# ---------------------------------------------------------------------------
+
+
+def test_returned_with_zero_payout_and_one_in_range_amount_is_loss() -> None:
+    """RETURNED + $0.00 substring + only the wager in [0.25, 500]: confident loss.
+
+    Regression for FanDuel 'Finished' cards where the wager renders in-range
+    (e.g. $0.50) but $0.00 fails the range filter -- we still want a loss,
+    not an ambiguous skip.
+    """
+    card_text = "\n".join([
+        "FANDUEL",
+        "SPORTSBOOK",
+        "Houston Astros ML",
+        "+116",
+        "MONEYLINE",
+        "$0.50",
+        "$0.00",
+        "TOTAL WAGER",
+        "RETURNED",
+        "BET ID: 0/0084650/9999252",
+        "PLACED: 5/10/2026 6:32PM ET",
+    ])
+    bets = BOT._parse_fd_settled_cards(card_text)
+    actual = _actual_bets(bets)
+    assert len(actual) == 1
+    assert actual[0]["result"] == "loss"
+    assert actual[0]["payout"] == 0.0
+    assert actual[0]["wager"] == 0.5
+
+
+def test_returned_with_one_amount_and_no_zero_marker_is_ambiguous() -> None:
+    """RETURNED + only one in-range amount AND no $0.00 anywhere: skip ambiguous.
+
+    Without an explicit $0.00 marker we can't tell if the missing dollar amount
+    was a payout (loss/void) or a winning return that OCR dropped. Better to
+    surface to the user than silently log as loss.
+    """
+    card_text = "\n".join([
+        "FANDUEL",
+        "SPORTSBOOK",
+        "Houston Astros ML",
+        "+116",
+        "MONEYLINE",
+        "$0.50",
+        "TOTAL WAGER",
+        "RETURNED",
+        "BET ID: 0/0084650/9999253",
+        "PLACED: 5/10/2026 6:32PM ET",
+    ])
+    bets = BOT._parse_fd_settled_cards(card_text)
+    skipped = [b for b in bets if b.get("_skipped")]
+    actual = _actual_bets(bets)
+
+    assert actual == []
+    assert len(skipped) == 1
+    assert skipped[0]["_skip_reason"] == "ambiguous_returned"
+    assert skipped[0]["bet_id"] == "0/0084650/9999253"
+    # BET ID must not be burned -- a cleaner re-screenshot should re-parse
+    assert "0/0084650/9999253" not in BOT._SEEN_FD_BET_IDS
+
+
+def test_ambiguous_returned_does_not_burn_bet_id() -> None:
+    """Ambiguous RETURNED skip lets a follow-up clean screenshot parse the bet."""
+    ambiguous_card = "\n".join([
+        "FANDUEL",
+        "SPORTSBOOK",
+        "Minnesota Twins ML",
+        "+100",
+        "MONEYLINE",
+        "$0.50",
+        "TOTAL WAGER",
+        "RETURNED",
+        "BET ID: 0/0084650/9999254",
+        "PLACED: 5/10/2026 6:32PM ET",
+    ])
+    clean_card = "\n".join([
+        "FANDUEL",
+        "SPORTSBOOK",
+        "Minnesota Twins ML",
+        "+100",
+        "MONEYLINE",
+        "$0.50",
+        "$0.00",
+        "TOTAL WAGER",
+        "RETURNED",
+        "BET ID: 0/0084650/9999254",
+        "PLACED: 5/10/2026 6:32PM ET",
+    ])
+    bets1 = BOT._parse_fd_settled_cards(ambiguous_card)
+    assert _actual_bets(bets1) == []
+
+    bets2 = BOT._parse_fd_settled_cards(clean_card)
+    actual2 = _actual_bets(bets2)
+    assert len(actual2) == 1
+    assert actual2[0]["result"] == "loss"
+    assert actual2[0]["bet_id"] == "0/0084650/9999254"
+
+
+def test_incomplete_skip_includes_line_for_user_feedback() -> None:
+    """Incomplete skip dicts should expose the parsed team line (when known).
+
+    Today's failure: an empty-bet_id partial card with line='Minnesota Twins ML'
+    and wager=0 produced no Telegram feedback because the skip dict only had
+    bet_id/wager/result/game -- none populated. Including `line` lets the
+    user know which card was missed.
+    """
+    card_text = "\n".join([
+        "FANDUEL",
+        "SPORTSBOOK",
+        "Minnesota Twins ML",
+        "+100",
+        "MONEYLINE",
+        "Minnesota Twins ( Ryan) @ Cleveland Guardia...",
+    ])
+    bets = BOT._parse_fd_settled_cards(card_text)
+    skipped = [b for b in bets if b.get("_skipped")]
+    # Card has no result keywords, no $ amounts -> unsettled/pending skip
+    assert len(skipped) == 1
+    s = skipped[0]
+    # team/line surface so the user can identify the missed bet
+    assert s.get("line") or s.get("team") or s.get("game")


### PR DESCRIPTION
## Summary
- Tightens the `RETURNED -> loss` path in `_parse_single_fd_settled_card`: now requires either >=2 in-range dollar amounts OR an explicit `$0.00` substring before committing to loss. Without either, the card is skipped with `_skip_reason="ambiguous_returned"` (bet_id NOT burned, so a follow-up clean screenshot still parses).
- Adds `line`/`team` fields to incomplete + ambiguous skip dicts so the Telegram summary can identify the missed card by team name when `bet_id` failed to OCR.
- Surfaces `ambiguous_returned` skips through the same per-card feedback path as `incomplete` skips, and guarantees one summary line per missed card (using `line` -> `team` -> `game` -> fallback string) so silent skips can no longer happen.

### Context
Today's `/settle` run produced four WARN lines in `telegram_bot.log` covering the parse failure modes we want to harden against. Three were duplicates that landed safely thanks to cross-screenshot dedup; the fourth (an empty-`bet_id` "Minnesota Twins ML" partial) generated zero user-facing feedback because the skip dict only carried `bet_id`/`wager`/`result`/`game` -- none populated. If any of those failure modes had been the *first* time the bot saw a bet, the failure modes were:
- `bet_id=...` + `RETURNED` + 1 in-range amount + no `$0.00`: committed to `loss` with `payout=0.0` even though the missing amount could have been a winning payout dropped by OCR.
- Empty `bet_id` + incomplete card: skipped silently; user never told.

## Test plan
- [x] `pytest tests/test_telegram_ocr_regression.py` -- 49 existing + 4 new tests pass.
- [x] Full suite: `pytest` -- 763 tests pass.
- [x] Red-green TDD verified: new tests fail on `develop` head and pass on this branch.
- New test coverage:
  - `test_returned_with_zero_payout_and_one_in_range_amount_is_loss` -- the existing happy path (today's bet_id 0000252 scenario: $0.50 wager, $0.00 payout, RETURNED) still resolves to loss.
  - `test_returned_with_one_amount_and_no_zero_marker_is_ambiguous` -- RETURNED with only the wager visible and no `$0.00` marker is now skipped with `_skip_reason="ambiguous_returned"`.
  - `test_ambiguous_returned_does_not_burn_bet_id` -- after an ambiguous skip, a later clean screenshot with the same `bet_id` parses successfully.
  - `test_incomplete_skip_includes_line_for_user_feedback` -- partial cards without `bet_id` still surface a `line`/`team`/`game` for the Telegram summary.

## Not in this PR (deliberately deferred)
- Cross-screenshot field merging (accumulate OCR fragments per `bet_id` across a batch before deciding what to log). Higher impact but larger refactor.
- Updating an existing CSV row if a later screenshot has cleaner data than what's already logged.
- Statement export / reconciliation pass.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>