### PR TITLE
Flag FanDuel WON cards as ambiguous when payout <= wager

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -1582,25 +1582,16 @@ def _parse_single_fd_settled_card(card_text: str) -> dict | None:
 
     # 7. Result-specific payout override
     if result == "win":
-        # Sanity check: a winning payout must exceed the wager. If OCR
-        # produced a bogus second dollar amount, recalculate from odds.
-        if payout <= wager and odds and wager > 0:
-            try:
-                odds_val = int(float(odds))
-                if odds_val < 0:
-                    calc_profit = wager * 100.0 / abs(odds_val)
-                else:
-                    calc_profit = wager * odds_val / 100.0
-                payout = round(wager + calc_profit, 2)
-                logger.warning(
-                    "FD settled card: OCR payout ($%.2f) <= wager ($%.2f), "
-                    "recalculated from odds %s -> $%.2f (bet_id=%s)",
-                    raw_amounts[1] if len(raw_amounts) >= 2 else 0.0,
-                    wager, odds, payout, bet_id,
-                )
-            except (ValueError, TypeError):
-                pass
-        profit = round(payout - wager, 2)
+        # If a winning payout doesn't exceed the wager, one of the two amounts
+        # is corrupt (e.g. "$1.17" OCR'd as "$1:17" -- colon stops the regex,
+        # so the won amount becomes the wager and the wager becomes the
+        # payout). Recalculating from odds trusts the wager and produces a
+        # confidently-wrong ledger row; skip as ambiguous instead so the user
+        # can re-screenshot.
+        if payout <= wager and wager > 0:
+            result = "ambiguous_recalc"
+        else:
+            profit = round(payout - wager, 2)
     elif result == "void":
         payout = wager  # void = wager refunded; override raw $0.00 from OCR
         profit = 0.0
@@ -1633,6 +1624,20 @@ def _parse_single_fd_settled_card(card_text: str) -> dict | None:
         )
         return {
             "_skipped": True, "_skip_reason": "ambiguous_returned", "_settled": True,
+            "platform": "FanDuel",
+            "bet_id": bet_id, "wager": wager, "result": result,
+            "game": game, "line": line, "team": team,
+        }
+
+    if result == "ambiguous_recalc":
+        logger.warning(
+            "FD settled card: WON but parsed payout ($%.2f) <= parsed wager "
+            "($%.2f) -- one amount is OCR-corrupt, skipping as ambiguous "
+            "(bet_id=%s line=%r odds=%s)",
+            payout, wager, bet_id, line, odds,
+        )
+        return {
+            "_skipped": True, "_skip_reason": "ambiguous_recalc", "_settled": True,
             "platform": "FanDuel",
             "bet_id": bet_id, "wager": wager, "result": result,
             "game": game, "line": line, "team": team,
@@ -2461,10 +2466,11 @@ async def cmd_delete(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 # Skip reasons that should surface as "Missed: ..." cards in the user feedback.
 # Anything else (dedup, unsettled) is shown via aggregate footer lines instead.
-_NEEDS_REVIEW_REASONS = ("incomplete", "ambiguous_returned")
+_NEEDS_REVIEW_REASONS = ("incomplete", "ambiguous_returned", "ambiguous_recalc")
 _SKIP_REASON_LABELS = {
     "incomplete": "incomplete",
     "ambiguous_returned": "ambiguous (RETURNED w/o $0.00)",
+    "ambiguous_recalc": "ambiguous (WON but payout <= wager, OCR corrupt)",
 }
 
 
@@ -2481,7 +2487,7 @@ def _format_missed_card_label(skip: dict) -> str:
     if wager > 0:
         parts.append(f"${wager:.2f}")
     result = skip.get("result")
-    if result and result not in ("pending", "ambiguous_returned"):
+    if result and result not in ("pending", "ambiguous_returned", "ambiguous_recalc"):
         parts.append(str(result).upper())
     return ", ".join(parts) if parts else "card with no identifying fields"
 

--- a/tests/test_telegram_ocr_regression.py
+++ b/tests/test_telegram_ocr_regression.py
@@ -447,25 +447,33 @@ def test_fanduel_finished_date_falls_back_to_placed(tmp_path, monkeypatch) -> No
 
 
 def test_fanduel_finished_multi_card() -> None:
-    """Multi-card Finished screenshot should parse each card correctly."""
+    """Multi-card Finished screenshot should parse each card correctly.
+
+    UTSA card in the fixture has WON/TOTAL WAGER labels swapped vs the dollar
+    amounts (wager=$1.00 visually, but OCR ordered the amounts as $1.91 then
+    $1.00). That's an OCR-corrupt reading that now skips as ambiguous_recalc
+    rather than being silently "rescued" by recalculating from odds.
+    """
     raw = _read_fixture("fanduel_finished_multi.txt")
     bets = BOT._parse_fd_settled_cards(raw)
     actual = _actual_bets(bets)
+    skipped = [b for b in bets if b.get("_skipped")]
 
     by_id = {b["bet_id"]: b for b in actual if b.get("bet_id")}
+    skipped_by_id = {b["bet_id"]: b for b in skipped if b.get("bet_id")}
 
-    # Alabama -14.5 should be win
+    # Alabama -14.5 should be win (payout > wager, no recalc needed)
     assert "0/0084650/0000187" in by_id
     assert by_id["0/0084650/0000187"]["result"] == "win"
     assert by_id["0/0084650/0000187"]["line"] == "Alabama -14.5"
 
-    # UTSA +4.5 should be win (spread header now captured with >= 0.5 threshold)
-    assert "0/0084650/0000189" in by_id
-    assert by_id["0/0084650/0000189"]["result"] == "win"
-    assert by_id["0/0084650/0000189"]["line"] == "UTSA +4.5"
+    # UTSA +4.5: payout <= wager after parse -> ambiguous_recalc skip
+    assert "0/0084650/0000189" in skipped_by_id
+    assert skipped_by_id["0/0084650/0000189"]["_skip_reason"] == "ambiguous_recalc"
+    assert skipped_by_id["0/0084650/0000189"]["line"] == "UTSA +4.5"
 
-    # Cleveland State card is truncated (no bet_id), so only 2 cards parse fully
-    assert len(actual) == 2, f"Expected 2 parseable cards, got {len(actual)}"
+    # Only Alabama parses fully; UTSA is skipped, Cleveland State is truncated
+    assert len(actual) == 1, f"Expected 1 parseable card, got {len(actual)}"
 
 
 def test_fanduel_finished_is_detected_as_settled() -> None:
@@ -1113,6 +1121,113 @@ def test_returned_with_zero_dollar_zero_single_decimal_is_loss() -> None:
     actual = _actual_bets(bets)
     assert len(actual) == 1
     assert actual[0]["result"] == "loss"
+
+
+def test_won_card_with_corrupted_payout_amount_is_ambiguous() -> None:
+    """Reproduce bet 0/0084650/0000254: OCR misread "$1.17" as "$1:17" (colon for period).
+
+    The dollar regex stops at the colon, so:
+      - parsed wager = $1 (from "$1:17")
+      - parsed payout = $0.50 (the actual wager)
+    The win-sanity recalc then "rescues" the bad payout from odds, producing a
+    confidently-wrong ledger row ($1.00 stake / $2.34 payout for a bet that was
+    actually $0.50 / $1.17). When the recalc fires we know one amount is
+    already corrupt -- skip the card so the user can re-screenshot.
+    """
+    card_text = "\n".join([
+        "FANDUEL",
+        "SPORTSBOOK",
+        "+134",
+        "Washington Nationals",
+        "MONEYLINE",
+        "Washington Nationals...",
+        "Cincinnati Reds (N Lo...",
+        "$1:17",
+        "$0.50",
+        "TOTAL WAGER",
+        "WON ON FANDUEL",
+        "BET ID: 0/0084650/9999254",
+        "PLACED: 5/12/2026 10:35PM ET",
+    ])
+    bets = BOT._parse_fd_settled_cards(card_text)
+    skipped = [b for b in bets if b.get("_skipped")]
+    actual = _actual_bets(bets)
+
+    assert actual == []
+    assert len(skipped) == 1
+    assert skipped[0]["_skip_reason"] == "ambiguous_recalc"
+    assert skipped[0]["bet_id"] == "0/0084650/9999254"
+    # BET ID must not be burned -- a cleaner re-screenshot should re-parse
+    assert "0/0084650/9999254" not in BOT._SEEN_FD_BET_IDS
+
+
+def test_ambiguous_recalc_does_not_burn_bet_id() -> None:
+    """A clean re-screenshot must still parse after an ambiguous_recalc skip."""
+    corrupted = "\n".join([
+        "FANDUEL",
+        "SPORTSBOOK",
+        "+134",
+        "Washington Nationals",
+        "MONEYLINE",
+        "Washington Nationals...",
+        "Cincinnati Reds (N Lo...",
+        "$1:17",
+        "$0.50",
+        "TOTAL WAGER",
+        "WON ON FANDUEL",
+        "BET ID: 0/0084650/9999264",
+        "PLACED: 5/12/2026 10:35PM ET",
+    ])
+    clean = "\n".join([
+        "FANDUEL",
+        "SPORTSBOOK",
+        "+134",
+        "Washington Nationals",
+        "MONEYLINE",
+        "Washington Nationals...",
+        "Cincinnati Reds (N Lo...",
+        "$0.50",
+        "$1.17",
+        "TOTAL WAGER",
+        "WON ON FANDUEL",
+        "BET ID: 0/0084650/9999264",
+        "PLACED: 5/12/2026 10:35PM ET",
+    ])
+    bets1 = BOT._parse_fd_settled_cards(corrupted)
+    assert _actual_bets(bets1) == []
+
+    bets2 = BOT._parse_fd_settled_cards(clean)
+    actual2 = _actual_bets(bets2)
+    assert len(actual2) == 1
+    assert actual2[0]["result"] == "win"
+    assert actual2[0]["wager"] == 0.5
+    assert actual2[0]["payout"] == 1.17
+    assert actual2[0]["bet_id"] == "0/0084650/9999264"
+
+
+def test_normal_winning_card_still_parses_after_recalc_change() -> None:
+    """Regression: an ordinary winning card (payout > wager) must keep parsing."""
+    card_text = "\n".join([
+        "FANDUEL",
+        "SPORTSBOOK",
+        "Boston Red Sox",
+        "-132",
+        "MONEYLINE",
+        "Philadelphia Phillies (...",
+        "Boston Red Sox (S Gr...",
+        "$0.50",
+        "$0.88",
+        "TOTAL WAGER",
+        "WON ON FANDUEL",
+        "BET ID: 0/0084650/9999255",
+        "PLACED: 5/12/2026 10:35PM ET",
+    ])
+    bets = BOT._parse_fd_settled_cards(card_text)
+    actual = _actual_bets(bets)
+    assert len(actual) == 1
+    assert actual[0]["result"] == "win"
+    assert actual[0]["wager"] == 0.5
+    assert actual[0]["payout"] == 0.88
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_telegram_ocr_regression.py
+++ b/tests/test_telegram_ocr_regression.py
@@ -1257,11 +1257,13 @@ def test_format_missed_card_label_handles_all_empty_fields() -> None:
 
 
 def test_format_missed_card_label_hides_internal_result_values() -> None:
-    """`pending` and `ambiguous_returned` are internal sentinels -- don't surface them."""
+    """`pending`, `ambiguous_returned`, and `ambiguous_recalc` are internal sentinels."""
     pending = BOT._format_missed_card_label({"line": "X ML", "result": "pending"})
     ambiguous = BOT._format_missed_card_label({"line": "X ML", "result": "ambiguous_returned"})
+    recalc = BOT._format_missed_card_label({"line": "X ML", "result": "ambiguous_recalc"})
     assert "PENDING" not in pending
     assert "AMBIGUOUS_RETURNED" not in ambiguous
+    assert "AMBIGUOUS_RECALC" not in recalc
 
 
 def test_build_skip_feedback_emits_one_line_per_needs_review_card() -> None:


### PR DESCRIPTION
## Summary

- When a WON FanDuel settled card parses with `payout <= wager`, one of the two dollar amounts is OCR-corrupt (e.g. `\$1.17` misread as `\$1:17` -- the colon stops the dollar regex). Previously the parser trusted the wager and recalculated payout from odds, silently writing a confidently-wrong ledger row.
- Caught on bet `0/0084650/0000254` (Washington Nationals ML +134, 5/12): actual screenshot was \$0.50 wager / \$1.17 won, but got logged as \$1.00 wager / \$2.34 payout.
- Now those cards skip as `ambiguous_recalc` and surface as "Missed" feedback so a clean re-screenshot can re-parse them. BET ID is not burned.
- Updated `test_fanduel_finished_multi_card` to reflect that the UTSA fixture (labels swapped in OCR) is also a victim of the same silent-rescue and now correctly skips.

## Test plan

- [x] `pytest tests/test_telegram_ocr_regression.py` (65/65 passing, includes 3 new tests + 1 updated existing test)
- [x] Full suite: `pytest tests/` (729/729 passing)
- [ ] Manual verification: send a real FanDuel settled-bets screenshot; confirm normal cards parse and any future colon-decimal OCR misreads surface as Missed cards
- [ ] Local ledger fix for the historical bet 0000254 (data/betting_history.csv -- gitignored, not in PR)