### PR TITLE
Add scripts/run-stack.sh to launch Streamlit + Telegram bot together

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ betting_history.csv
 draft_results.csv
 
 telegram_bot.log
+streamlit.log
 .telegram_bot.lock
 .kalshi_sync_state.json
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Predictions now include both spread picks and Kalshi game-market picks when avai
 uv run streamlit run app.py
 ```
 Use the in-app league selector to switch between Men's CBB, Women's CBB, and MLB.
+
+### Run Dashboard + Telegram Bot Together
+```bash
+./scripts/run-stack.sh
+```
+Starts Streamlit in the background (logs to `streamlit.log`) and the Telegram bot in the foreground. Ctrl-C stops both.
 Use the in-app **Jump to section** control to quickly navigate directly to:
 - Spread Value Bets
 - Kalshi Game Markets

--- a/README.md
+++ b/README.md
@@ -28,12 +28,6 @@ Predictions now include both spread picks and Kalshi game-market picks when avai
 uv run streamlit run app.py
 ```
 Use the in-app league selector to switch between Men's CBB, Women's CBB, and MLB.
-
-### Run Dashboard + Telegram Bot Together
-```bash
-./scripts/run-stack.sh
-```
-Starts Streamlit in the background (logs to `streamlit.log`) and the Telegram bot in the foreground. Ctrl-C stops both.
 Use the in-app **Jump to section** control to quickly navigate directly to:
 - Spread Value Bets
 - Kalshi Game Markets
@@ -41,6 +35,12 @@ Use the in-app **Jump to section** control to quickly navigate directly to:
 - Betting Log
 - Performance History
 - System
+
+### Run Dashboard + Telegram Bot Together
+```bash
+./scripts/run-stack.sh
+```
+Starts both services as background process groups (Streamlit logs to `streamlit.log`, the bot logs to `telegram_bot.log`). Cleanup runs on Ctrl-C, SIGTERM, or normal exit, so neither service is left orphaned. If Streamlit crashes immediately, the last 20 lines of `streamlit.log` are printed before the script aborts.
 
 ### Multi-League Commands
 

--- a/scripts/run-stack.sh
+++ b/scripts/run-stack.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Launch the Streamlit dashboard and the Telegram bot together.
+#
+# Streamlit runs in the background; its logs go to streamlit.log.
+# The Telegram bot runs in the foreground so its output stays visible.
+# Ctrl-C (SIGINT) or a TERM signal stops both cleanly.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+STREAMLIT_LOG="$REPO_ROOT/streamlit.log"
+
+# Track the Streamlit child so we can clean it up on exit.
+STREAMLIT_PID=""
+
+cleanup() {
+    local code=$?
+    if [[ -n "$STREAMLIT_PID" ]] && kill -0 "$STREAMLIT_PID" 2>/dev/null; then
+        echo
+        echo "[run-stack] Stopping Streamlit (pid $STREAMLIT_PID)..."
+        kill "$STREAMLIT_PID" 2>/dev/null || true
+        # Give it a moment to shut down, then force if needed.
+        for _ in 1 2 3 4 5; do
+            kill -0 "$STREAMLIT_PID" 2>/dev/null || break
+            sleep 0.5
+        done
+        kill -9 "$STREAMLIT_PID" 2>/dev/null || true
+    fi
+    exit "$code"
+}
+trap cleanup INT TERM EXIT
+
+echo "[run-stack] Starting Streamlit (logs: $STREAMLIT_LOG)..."
+uv run streamlit run app.py >>"$STREAMLIT_LOG" 2>&1 &
+STREAMLIT_PID=$!
+echo "[run-stack] Streamlit pid $STREAMLIT_PID"
+
+# Brief pause so an immediate Streamlit crash surfaces before the bot starts.
+sleep 1
+if ! kill -0 "$STREAMLIT_PID" 2>/dev/null; then
+    echo "[run-stack] Streamlit failed to start. Check $STREAMLIT_LOG"
+    exit 1
+fi
+
+echo "[run-stack] Starting Telegram bot in foreground (Ctrl-C to stop both)..."
+uv run python telegram_bot.py

--- a/scripts/run-stack.sh
+++ b/scripts/run-stack.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 # Launch the Streamlit dashboard and the Telegram bot together.
 #
-# Streamlit runs in the background; its logs go to streamlit.log.
-# The Telegram bot runs in the foreground so its output stays visible.
-# Ctrl-C (SIGINT) or a TERM signal stops both cleanly.
+# Both services run as background process groups so the cleanup trap can
+# signal the actual Python child (not just the `uv run` wrapper) via a
+# process-group kill. Cleanup runs on any exit path -- SIGINT, SIGTERM, or
+# the script exiting normally -- so neither service is ever orphaned.
+#
+# The bot is the lead process: when it exits, the script exits and the EXIT
+# trap stops Streamlit. Streamlit output is appended to streamlit.log with a
+# session header per run; the bot writes to telegram_bot.log via its own
+# logging config.
 
 set -euo pipefail
 
@@ -12,37 +18,88 @@ cd "$REPO_ROOT"
 
 STREAMLIT_LOG="$REPO_ROOT/streamlit.log"
 
-# Track the Streamlit child so we can clean it up on exit.
+# Preconditions: surface missing deps with an actionable message rather than
+# letting them fall out as a deep import error inside the children.
+command -v uv >/dev/null 2>&1 \
+    || { echo "[run-stack] ERROR: 'uv' not found in PATH" >&2; exit 1; }
+[[ -f app.py ]] \
+    || { echo "[run-stack] ERROR: app.py not found in $REPO_ROOT" >&2; exit 1; }
+[[ -f telegram_bot.py ]] \
+    || { echo "[run-stack] ERROR: telegram_bot.py not found in $REPO_ROOT" >&2; exit 1; }
+
+# Initialize empty so cleanup() is safe even if we die before launching.
 STREAMLIT_PID=""
+BOT_PID=""
+
+# Stop a process group: SIGTERM, wait up to ~2.5s (5 x 0.5s), then SIGKILL.
+# Targets the group (`-pgid`) rather than a single pid because `uv run` is a
+# wrapper and signaling only its pid may not propagate to the actual child.
+stop_group() {
+    local pid="$1" label="$2"
+    [[ -n "$pid" ]] || return 0
+    kill -0 "$pid" 2>/dev/null || return 0
+    echo "[run-stack] Stopping $label (pgid $pid)..."
+    if ! kill -TERM -- "-$pid" 2>/dev/null; then
+        echo "[run-stack] WARNING: failed to send SIGTERM to $label pgid $pid" >&2
+    fi
+    for _ in 1 2 3 4 5; do
+        kill -0 "$pid" 2>/dev/null || return 0
+        sleep 0.5
+    done
+    kill -KILL -- "-$pid" 2>/dev/null || true
+    if kill -0 "$pid" 2>/dev/null; then
+        echo "[run-stack] WARNING: $label pgid $pid survived SIGKILL -- manual cleanup required" >&2
+    fi
+}
 
 cleanup() {
     local code=$?
-    if [[ -n "$STREAMLIT_PID" ]] && kill -0 "$STREAMLIT_PID" 2>/dev/null; then
-        echo
-        echo "[run-stack] Stopping Streamlit (pid $STREAMLIT_PID)..."
-        kill "$STREAMLIT_PID" 2>/dev/null || true
-        # Give it a moment to shut down, then force if needed.
-        for _ in 1 2 3 4 5; do
-            kill -0 "$STREAMLIT_PID" 2>/dev/null || break
-            sleep 0.5
-        done
-        kill -9 "$STREAMLIT_PID" 2>/dev/null || true
+    # Disarm to avoid re-entry from a second signal during the kill window.
+    trap - INT TERM EXIT
+    stop_group "$BOT_PID" "Telegram bot"
+    stop_group "$STREAMLIT_PID" "Streamlit"
+    if [[ "$code" -ne 0 ]]; then
+        echo "[run-stack] Exit code: $code"
     fi
     exit "$code"
 }
 trap cleanup INT TERM EXIT
 
+# Mark this run in streamlit.log so a failure tail at the bottom of this
+# script doesn't mix output from a previous session.
+echo "===== [run-stack] $(date -Iseconds) pid=$$ =====" >>"$STREAMLIT_LOG"
+
+# Job control puts each backgrounded command in its own process group with
+# pgid == pid, which is what `kill -- -pgid` in stop_group depends on.
+set -m
+
 echo "[run-stack] Starting Streamlit (logs: $STREAMLIT_LOG)..."
 uv run streamlit run app.py >>"$STREAMLIT_LOG" 2>&1 &
 STREAMLIT_PID=$!
-echo "[run-stack] Streamlit pid $STREAMLIT_PID"
+echo "[run-stack] Streamlit pgid $STREAMLIT_PID"
 
-# Brief pause so an immediate Streamlit crash surfaces before the bot starts.
-sleep 1
+# Wait up to ~1s (5 x 0.2s) so a fast Streamlit crash (import error, missing
+# dep) surfaces before we hand off to the bot. This does NOT verify Streamlit
+# bound port 8501 -- only that the process didn't die immediately.
+for _ in 1 2 3 4 5; do
+    sleep 0.2
+    kill -0 "$STREAMLIT_PID" 2>/dev/null || break
+done
 if ! kill -0 "$STREAMLIT_PID" 2>/dev/null; then
-    echo "[run-stack] Streamlit failed to start. Check $STREAMLIT_LOG"
+    wait "$STREAMLIT_PID" 2>/dev/null
+    streamlit_exit=$?
+    echo "[run-stack] ERROR: Streamlit exited with code $streamlit_exit before bot could start." >&2
+    echo "[run-stack] Last 20 lines of $STREAMLIT_LOG:" >&2
+    tail -n 20 "$STREAMLIT_LOG" >&2 || echo "[run-stack] (could not read $STREAMLIT_LOG)" >&2
     exit 1
 fi
 
-echo "[run-stack] Starting Telegram bot in foreground (Ctrl-C to stop both)..."
-uv run python telegram_bot.py
+echo "[run-stack] Starting Telegram bot in background (Ctrl-C to stop both)..."
+uv run python telegram_bot.py &
+BOT_PID=$!
+echo "[run-stack] Telegram bot pgid $BOT_PID"
+
+# Wait on the bot specifically: bare `wait` would return as soon as either
+# child exits. When the bot exits (cleanly or otherwise), the EXIT trap
+# stops Streamlit and the script propagates the bot's exit code.
+wait "$BOT_PID"


### PR DESCRIPTION
## Summary
Adds a single-command launcher that starts both the Streamlit dashboard and the Telegram bot. Streamlit runs in the background (output redirected to `streamlit.log`); the Telegram bot runs in the foreground so you can read its logs live. Ctrl-C or SIGTERM cleanly shuts down both via a bash `trap`.

## Usage
\`\`\`bash
./scripts/run-stack.sh
\`\`\`

## Notes
- Does **not** generate predictions — `data/daily_predictions.csv` still needs `uv run python predict.py` (or the league-specific equivalent) to be populated. The `/today` empty-file crash in `cmd_today` is a separate issue not addressed here.
- `streamlit.log` is gitignored.
- README updated under "Run Dashboard + Telegram Bot Together".

## Test plan
1. Stop any currently-running Streamlit or Telegram bot processes.
2. \`./scripts/run-stack.sh\`
3. Verify Streamlit reachable at http://localhost:8501 and bot responds to `/pending` in Telegram.
4. Ctrl-C — both processes should exit cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)